### PR TITLE
Simplify data receiving.

### DIFF
--- a/sherpa/bin/conformer_rnnt/decode_manifest.py
+++ b/sherpa/bin/conformer_rnnt/decode_manifest.py
@@ -35,7 +35,7 @@ import websockets
 from icefall.utils import store_transcripts, write_error_stats
 from lhotse import CutSet, load_manifest
 
-DEFAULT_MANIFEST_FILENAME = "/ceph-fj/fangjun/open-source-2/icefall-master-2/egs/librispeech/ASR/data/fbank/cuts_test-clean.json.gz"  # noqa
+DEFAULT_MANIFEST_FILENAME = "/ceph-fj/fangjun/open-source/icefall-tdnnf/egs/librispeech/ASR/data/fbank/librispeech_cuts_test-clean.jsonl.gz"
 
 
 def get_args():
@@ -132,6 +132,7 @@ async def send(
                 results.append(
                     (c.supervisions[0].text.split(), decoding_results.split())
                 )  # noqa
+        await websocket.send(b"Done")
 
     return total_duration, results
 

--- a/sherpa/bin/conformer_rnnt/offline_client.py
+++ b/sherpa/bin/conformer_rnnt/offline_client.py
@@ -91,6 +91,7 @@ async def run(server_addr: str, server_port: int, test_wavs: List[str]):
             decoding_results = await websocket.recv()
             print(test_wav, "\n", decoding_results)
             print()
+        await websocket.send(b"Done")
 
 
 async def main():

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
@@ -98,19 +98,12 @@ async def run(server_addr: str, server_port: int, test_wav: str):
             end = start + chunk_size
             d = wave.numpy().data[start:end]
 
-            num_bytes = d.nbytes
-            await websocket.send((num_bytes).to_bytes(8, "little", signed=True))
-
             await websocket.send(d)
             await asyncio.sleep(sleep_time)  # in seconds
 
             start = end
 
-        s = b"Done"
-        await websocket.send((len(s)).to_bytes(8, "little", signed=True))
-        await websocket.send(s)
-
-        logging.info("Send done")
+        await websocket.send(b"Done")
 
         decoding_results = await receive_task
         logging.info(f"{test_wav}\n{decoding_results}")

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
@@ -414,9 +414,8 @@ class StreamingServer(object):
             decoder_out=self.initial_decoder_out,
         )
 
-        last = b""
         while True:
-            samples, last = await self.recv_audio_samples(socket, last)
+            samples = await self.recv_audio_samples(socket)
             if samples is None:
                 break
 
@@ -447,67 +446,22 @@ class StreamingServer(object):
     async def recv_audio_samples(
         self,
         socket: websockets.WebSocketServerProtocol,
-        last: Optional[bytes] = None,
-    ) -> Tuple[Optional[torch.Tensor], Optional[bytes]]:
+    ) -> Optional[torch.Tensor]:
         """Receives a tensor from the client.
 
-        The message from the client contains two parts: header and payload
-
-            - the header contains 8 bytes in little endian format, specifying
-              the number of bytes in the payload.
-
-            - the payload contains either a binary representation of the 1-D
-              torch.float32 tensor or the bytes object b"Done" which means
-              the end of utterance.
+        Each message contains either a bytes buffer containing audio samples
+        in 16 kHz or contains b"Done" meaning the end of utterance.
 
         Args:
           socket:
             The socket for communicating with the client.
-          last:
-            Previous received content.
         Returns:
-          Return a tuple containing:
-            - A 1-D torch.float32 tensor containing the audio samples
-            - Data for the next chunk, if any
-         or return a tuple (None, None) meaning the end of utterance.
+          Return a 1-D torch.float32 tensor containing the audio samples or
+          return None.
         """
-        header_len = 8
-
-        if last is None:
-            last = b""
-
-        async def receive_header():
-            buf = last
-            async for message in socket:
-                buf += message
-                if len(buf) >= header_len:
-                    break
-            if buf:
-                header = buf[:header_len]
-                remaining = buf[header_len:]
-            else:
-                header = None
-                remaining = None
-
-            return header, remaining
-
-        header, received = await receive_header()
-
-        if header is None:
-            return None, None
-
-        expected_num_bytes = int.from_bytes(header, "little", signed=True)
-
-        async for message in socket:
-            received += message
-            if len(received) >= expected_num_bytes:
-                break
-
-        if not received or received == b"Done":
-            return None, None
-
-        this_chunk = received[:expected_num_bytes]
-        next_chunk = received[expected_num_bytes:]
+        message = await socket.recv()
+        if message == b"Done":
+            return None
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -515,13 +469,10 @@ class StreamingServer(object):
             # We ignore it here as we are not going to write it anyway.
             if hasattr(torch, "frombuffer"):
                 # Note: torch.frombuffer is available only in torch>= 1.10
-                return (
-                    torch.frombuffer(this_chunk, dtype=torch.float32),
-                    next_chunk,
-                )  # noqa
+                return torch.frombuffer(message, dtype=torch.float32)
             else:
-                array = np.frombuffer(this_chunk, dtype=np.float32)
-                return torch.from_numpy(array), next_chunk
+                array = np.frombuffer(message, dtype=np.float32)
+                return torch.from_numpy(array)
 
 
 @torch.no_grad()

--- a/sherpa/bin/web/js/streaming_record.js
+++ b/sherpa/bin/web/js/streaming_record.js
@@ -102,11 +102,6 @@ if (navigator.mediaDevices.getUserMedia) {
         buf[i] = s * 32767;
       }
 
-      const header = new ArrayBuffer(8);
-      new DataView(header).setInt32(
-          0, samples.byteLength, true /* littleEndian */);
-
-      socket.send(new BigInt64Array(header, 0, 1));
       socket.send(samples);
 
       leftchannel.push(buf);
@@ -130,6 +125,15 @@ if (navigator.mediaDevices.getUserMedia) {
 
     stopBtn.onclick = function() {
       console.log('recorder stopped');
+
+      let done = new Int8Array(4);  // Done
+      done[0] = 68;                 //'D';
+      done[1] = 111;                //'o';
+      done[2] = 110;                //'n';
+      done[3] = 101;                //'e';
+      socket.send(done);
+      console.log('Sent Done');
+
       socket.close();
 
       // stopBtn recording

--- a/sherpa/bin/web/js/upload.js
+++ b/sherpa/bin/web/js/upload.js
@@ -37,12 +37,10 @@ function initWebSocket() {
   });
 }
 
-function send_data(buf) {
+function send_header(n) {
   const header = new ArrayBuffer(8);
-  new DataView(header).setInt32(0, buf.byteLength, true /* littleEndian */);
+  new DataView(header).setInt32(0, n, true /* littleEndian */);
   socket.send(new BigInt64Array(header, 0, 1));
-
-  socket.send(buf);
 }
 
 function onFileChange() {
@@ -86,8 +84,9 @@ function onFileChange() {
     let buf = float32_samples.buffer
     let n = 1024 * 4;  // send this number of bytes per request.
     console.log('buf length, ' + buf.byteLength);
+    send_header(buf.byteLength);
     for (let start = 0; start < buf.byteLength; start += n) {
-      send_data(buf.slice(start, start + n));
+      socket.send(buf.slice(start, start + n));
     }
 
     let done = new Int8Array(4);  // Done
@@ -95,7 +94,7 @@ function onFileChange() {
     done[1] = 111;                //'o';
     done[2] = 110;                //'n';
     done[3] = 101;                //'e';
-    send_data(done);
+    socket.send(done);
   };
 
   reader.readAsArrayBuffer(file);


### PR DESCRIPTION
The websocket protocol is message-based and we can receive the message from the client in whole by a single call `socket.recv()`, which simplifies the code a lot.