### PR TITLE
WIP: Add timestamp

### DIFF
--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/decode.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/decode.py
@@ -147,6 +147,13 @@ class Stream(object):
         self.hyp = [blank_id] * context_size
         self.log_eps = math.log(1e-10)
 
+        # It has the same shape as self.hyp
+        # self.timestamps[i] is the frame number on which self.hyp[i] is decoded
+        self.timestamps = []
+
+        # It indicates how many frames after subsampling the model has processed
+        self.frame_offset = 0
+
     def accept_waveform(
         self,
         sampling_rate: float,

--- a/sherpa/bin/streaming_conformer_rnnt/decode.py
+++ b/sherpa/bin/streaming_conformer_rnnt/decode.py
@@ -73,6 +73,10 @@ class Stream(object):
         # The number of frames (after subsampling) been processed.
         self.processed_frames = 0
 
+        # It has the same shape as self.hyp
+        # self.timestamps[i] is the frame number on which self.hyp[i] is decoded
+        self.timestamps = []
+
         self.context_size = context_size
         self.hyp = [blank_id] * context_size
         self.log_eps = math.log(1e-10)

--- a/sherpa/csrc/hypothesis.h
+++ b/sherpa/csrc/hypothesis.h
@@ -32,6 +32,9 @@ struct Hypothesis {
   // The predicted tokens so far. Newly predicated tokens are appended.
   std::vector<int32_t> ys;
 
+  // timestamps[i] contains the frame number on which ys[i] is decoded
+  std::vector<int32_t> timestamps;
+
   // The total score of ys in log space.
   double log_prob = 0;
 

--- a/sherpa/csrc/rnnt_beam_search.cc
+++ b/sherpa/csrc/rnnt_beam_search.cc
@@ -208,10 +208,12 @@ GreedySearch(RnntModel &model,  // NOLINT
   return {ans_hyps, ans_timestamps};
 }
 
-torch::Tensor StreamingGreedySearch(RnntModel &model,  // NOLINT
-                                    torch::Tensor encoder_out,
-                                    torch::Tensor decoder_out,
-                                    std::vector<std::vector<int32_t>> *hyps) {
+torch::Tensor StreamingGreedySearch(
+    RnntModel &model,  // NOLINT
+    torch::Tensor encoder_out, torch::Tensor decoder_out,
+    const std::vector<int32_t> &frame_offset,
+    std::vector<std::vector<int32_t>> *hyps,
+    std::vector<std::vector<int32_t>> *timestamps) {
   TORCH_CHECK(encoder_out.dim() == 3, encoder_out.dim(), " vs ", 3);
   TORCH_CHECK(decoder_out.dim() == 2, decoder_out.dim(), " vs ", 2);
 
@@ -245,6 +247,7 @@ torch::Tensor StreamingGreedySearch(RnntModel &model,  // NOLINT
       if (index != blank_id && index != unk_id) {
         emitted = true;
         (*hyps)[n].push_back(index);
+        (*timestamps)[n].push_back(t + frame_offset[n]);
       }
     }
 

--- a/sherpa/csrc/rnnt_beam_search.h
+++ b/sherpa/csrc/rnnt_beam_search.h
@@ -58,14 +58,18 @@ GreedySearch(RnntModel &model,  // NOLINT
  *                    device as `model`.
  * @param decoder_out A 2-D tensor of shape (N, C). It should be on the same
  *                    device as `model`.
+ * @param frame_offset TODO
  * @param hyps The decoded tokens. Note: It is modified in-place.
+ * @param timestamps TODO
  *
  * @return Return the decoder output for the next chunk.
  */
-torch::Tensor StreamingGreedySearch(RnntModel &model,  // NOLINT
-                                    torch::Tensor encoder_out,
-                                    torch::Tensor decoder_out,
-                                    std::vector<std::vector<int32_t>> *hyps);
+torch::Tensor StreamingGreedySearch(
+    RnntModel &model,  // NOLINT
+    torch::Tensor encoder_out, torch::Tensor decoder_out,
+    const std::vector<int32_t> &frame_offset,
+    std::vector<std::vector<int32_t>> *hyps,
+    std::vector<std::vector<int32_t>> *timestamps);
 
 /** RNN-T modified beam search for offline recognition.
  *

--- a/sherpa/csrc/rnnt_beam_search.h
+++ b/sherpa/csrc/rnnt_beam_search.h
@@ -18,6 +18,7 @@
 #ifndef SHERPA_CSRC_RNNT_BEAM_SEARCH_H_
 #define SHERPA_CSRC_RNNT_BEAM_SEARCH_H_
 
+#include <utility>
 #include <vector>
 
 #include "sherpa/csrc/rnnt_conformer_model.h"
@@ -39,13 +40,16 @@ namespace sherpa {
  *                         and its shape is (batch_size,). Also, it must be
  *                         on CPU.
  *
- * @return Return A list-of-list of token IDs containing the decoded results.
- * The returned vector has size `batch_size` and each entry contains the
- * decoded results for the corresponding input in encoder_out.
+ * @return Return a pair containing:
+ *  - A list-of-list of token IDs containing the decoded results. The vector
+ *    has size `batch_size` and each entry contains the decoded results
+ *    for the corresponding input in encoder_out.
+ *  - A list-of-list of frame numbers specifying on which frame the
+ *    corresponding token ID is decoded.
  */
-std::vector<std::vector<int32_t>> GreedySearch(
-    RnntModel &model,  // NOLINT
-    torch::Tensor encoder_out, torch::Tensor encoder_out_length);
+std::pair<std::vector<std::vector<int32_t>>, std::vector<std::vector<int32_t>>>
+GreedySearch(RnntModel &model, torch::Tensor encoder_out,
+             torch::Tensor encoder_out_length);
 
 /** Greedy search for streaming recognition.
  *

--- a/sherpa/csrc/rnnt_beam_search.h
+++ b/sherpa/csrc/rnnt_beam_search.h
@@ -48,8 +48,8 @@ namespace sherpa {
  *    corresponding token ID is decoded.
  */
 std::pair<std::vector<std::vector<int32_t>>, std::vector<std::vector<int32_t>>>
-GreedySearch(RnntModel &model, torch::Tensor encoder_out,
-             torch::Tensor encoder_out_length);
+GreedySearch(RnntModel &model,  // NOLINT
+             torch::Tensor encoder_out, torch::Tensor encoder_out_length);
 
 /** Greedy search for streaming recognition.
  *
@@ -86,14 +86,17 @@ torch::Tensor StreamingGreedySearch(RnntModel &model,  // NOLINT
  *                          sequences, the actual number of active path for
  *                          each utterance may be smaller than this value.
  *
- * @return Return A list-of-list of token IDs containing the decoded results.
- * The returned vector has size `batch_size` and each entry contains the
- * decoded results for the corresponding input in encoder_out.
+ * @return Return a pair containing:
+ *  - A list-of-list of token IDs containing the decoded results. The vector
+ *    has size `batch_size` and each entry contains the decoded results
+ *    for the corresponding input in encoder_out.
+ *  - A list-of-list of frame numbers specifying on which frame the
+ *    corresponding token ID is decoded.
  */
-std::vector<std::vector<int32_t>> ModifiedBeamSearch(
-    RnntModel &model,  // NOLINT
-    torch::Tensor encoder_out, torch::Tensor encoder_out_length,
-    int32_t num_active_paths = 4);
+std::pair<std::vector<std::vector<int32_t>>, std::vector<std::vector<int32_t>>>
+ModifiedBeamSearch(RnntModel &model,  // NOLINT
+                   torch::Tensor encoder_out, torch::Tensor encoder_out_length,
+                   int32_t num_active_paths = 4);
 
 }  // namespace sherpa
 

--- a/sherpa/python/CMakeLists.txt
+++ b/sherpa/python/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(csrc)
+add_subdirectory(test)

--- a/sherpa/python/csrc/rnnt_beam_search.cc
+++ b/sherpa/python/csrc/rnnt_beam_search.cc
@@ -91,14 +91,18 @@ void PybindRnntBeamSearch(py::module &m) {  // NOLINT
   m.def(
       "streaming_greedy_search",
       [](RnntModel &model, torch::Tensor encoder_out, torch::Tensor decoder_out,
-         std::vector<std::vector<int32_t>> &hyps)
-          -> std::pair<torch::Tensor, std::vector<std::vector<int32_t>>> {
-        decoder_out =
-            StreamingGreedySearch(model, encoder_out, decoder_out, &hyps);
-        return {decoder_out, hyps};
+         const std::vector<int32_t> &frame_offset,
+         std::vector<std::vector<int32_t>> &hyps,
+         std::vector<std::vector<int32_t>> &timestamps)
+          -> std::tuple<torch::Tensor, std::vector<std::vector<int32_t>>,
+                        std::vector<std::vector<int32_t>>> {
+        decoder_out = StreamingGreedySearch(model, encoder_out, decoder_out,
+                                            frame_offset, &hyps, &timestamps);
+        return {decoder_out, hyps, timestamps};
       },
       py::arg("model"), py::arg("encoder_out"), py::arg("decoder_out"),
-      py::arg("hyps"), py::call_guard<py::gil_scoped_release>());
+      py::arg("frame_offset"), py::arg("hyps"), py::arg("timestamps"),
+      py::call_guard<py::gil_scoped_release>());
 
   m.def("modified_beam_search", &ModifiedBeamSearch, py::arg("model"),
         py::arg("encoder_out"), py::arg("encoder_out_length"),

--- a/sherpa/python/csrc/rnnt_beam_search.cc
+++ b/sherpa/python/csrc/rnnt_beam_search.cc
@@ -75,9 +75,12 @@ Args:
     identical token sequences, the actual number of active path for each
     utterance may be smaller than this value.
 Returns:
-  Return A list-of-list of token IDs containing the decoded results. The
-  returned vector has size ``batch_size`` and each entry contains the
-  decoded results for the corresponding input in ``encoder_out``.
+  Return a pair containing:
+    - A list-of-list of token IDs containing the decoded results. The vector
+      has size `batch_size` and each entry contains the decoded results
+      for the corresponding input in encoder_out.
+    - A list-of-list of frame numbers specifying on which frame the
+      corresponding token ID is decoded.
 )doc";
 
 void PybindRnntBeamSearch(py::module &m) {  // NOLINT

--- a/sherpa/python/csrc/rnnt_beam_search.cc
+++ b/sherpa/python/csrc/rnnt_beam_search.cc
@@ -45,9 +45,12 @@ Args:
     Its dtype is ``torch.kLong`` and its shape is ``(batch_size,)``. Also,
     it must be on CPU.
 Returns:
-  Return A list-of-list of token IDs containing the decoded results. The
-  returned vector has size ``batch_size`` and each entry contains the
-  decoded results for the corresponding input in ``encoder_out``.
+  Return a pair containing:
+    - A list-of-list of token IDs containing the decoded results. The vector
+      has size `batch_size` and each entry contains the decoded results
+      for the corresponding input in encoder_out.
+    - A list-of-list of frame numbers specifying on which frame the
+      corresponding token ID is decoded.
 )doc";
 
 static constexpr const char *kModifiedBeamSearchDoc = R"doc(

--- a/sherpa/python/sherpa/__init__.py
+++ b/sherpa/python/sherpa/__init__.py
@@ -15,3 +15,5 @@ from _sherpa import (
     modified_beam_search,
     streaming_greedy_search,
 )
+
+from .timestamp import convert_timestamp

--- a/sherpa/python/sherpa/timestamp.py
+++ b/sherpa/python/sherpa/timestamp.py
@@ -1,0 +1,27 @@
+from typing import List
+
+
+def convert_timestamp(
+    frames: List[int],
+    subsampling_factor: int,
+    frame_shift_ms: float = 10,
+) -> List[float]:
+    """Convert frame numbers to time (in seconds) given subsampling factor
+    and frame shift (in milliseconds).
+
+    Args:
+      frames:
+        A list of frame numbers after subsampling.
+      subsampling_factor:
+        The subsampling factor of the model.
+      frame_shift_ms:
+        Frame shift in milliseconds between two contiguous frames.
+    Return:
+      Return the time in seconds corresponding to each given frame.
+    """
+    frame_shift = frame_shift_ms / 1000.0
+    ans = []
+    for f in frames:
+        ans.append(f * subsampling_factor * frame_shift)
+
+    return ans

--- a/sherpa/python/test/CMakeLists.txt
+++ b/sherpa/python/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+function(sherpa_add_py_test source)
+  get_filename_component(name ${source} NAME_WE)
+  set(name "${name}_py")
+
+  add_test(NAME ${name}
+    COMMAND
+      "${PYTHON_EXECUTABLE}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/${source}"
+  )
+
+  get_filename_component(sherpa_path ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
+
+  set_property(TEST ${name}
+    PROPERTY ENVIRONMENT "PYTHONPATH=${sherpa_path}:$<TARGET_FILE_DIR:_sherpa>:$ENV{PYTHONPATH}"
+  )
+endfunction()
+
+# please sort the files in alphabetic order
+set(py_test_files
+  test_timestamp.py
+)
+
+foreach(source IN LISTS py_test_files)
+  sherpa_add_py_test(${source})
+endforeach()

--- a/sherpa/python/test/test_timestamp.py
+++ b/sherpa/python/test/test_timestamp.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Copyright      2022  Xiaomi Corp.       (authors: Fangjun Kuang)
+#
+# See LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R  test_timestamp_py
+
+import unittest
+import sherpa
+
+
+class TestTimeStamp(unittest.TestCase):
+    def test_convert_timestamp(self):
+        subsampling_factor = 4
+        frame_shift_ms = 10
+
+        frames = [0, 1, 2, 3, 5, 8, 10]
+        timestamps = sherpa.convert_timestamp(
+            frames,
+            subsampling_factor=4,
+            frame_shift_ms=10,
+        )
+        for i in range(len(frames)):
+            assert timestamps[i] == (
+                frames[i] * subsampling_factor * frame_shift_ms / 1000
+            ), (frames[i], timestamps[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Here are some initial results.

For the following test wav (Note: Its name should be `1089-134686-0002.wav`, not `1089-134686-0001.wav`)
https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/blob/main/test_wavs/1089-134686-0001.wav

The ground truth word timestamp from  https://github.com/CorentinJ/librispeech-alignments
is
```
",AFTER,EARLY,NIGHTFALL,THE,YELLOW,LAMPS,WOULD,LIGHT,UP,HERE,AND,THERE,THE,SQUALID,QUARTER,OF,THE,BROTHELS,"                          
"0.360,0.730,1.040,1.770,1.900,2.160,2.590,2.760,3.070,3.270,3.520,3.660,4.090,4.210,4.780,5.310,5.420,5.500,6.160,6.625"
```

The predicted results of this PR using the pre-trained model from 
https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/tree/main/exp
are
```
2022-07-06 21:47:53,604 INFO [offline_server.py:667] Connected: ('127.0.0.1', 48118). Number of connections: 1/10
[('_AFTER', 0.0), ('_E', 0.28), ('AR', 0.44), ('LY', 0.56), ('_NIGHT', 0.88), ('F', 1.24), ('A', 1.36), ('LL', 1.44), ('_THE', 1.6), ('_YE', 1.76), ('LL', 1.8800000000000001), ('OW', 1.96), ('_LA', 2.16), ('M', 2.32), ('P', 2.44), ('S', 2.48), ('_WOULD', 2.6), ('_LIGHT', 2.8000000000000003), ('_UP', 3.08), ('_HE', 3.2800000000000002), ('RE', 3.4), ('_AND', 3.6), ('_THERE', 3.8000000000000003), ('_THE', 4.08), ('_S', 4.28), ('QUA', 4.32), ('LI', 4.48), ('D', 4.64), ('_', 4.84), ('QUA', 4.88), ('R', 5.04), ('TER', 5.12), ('_OF', 5.4), ('_THE', 5.5200000000000005), ('_B', 5.68), ('RO', 5.72), ('TH', 5.88), ('EL', 6.16), ('S', 6.36)]
[0.0, 0.28, 0.44, 0.56, 0.88, 1.24, 1.36, 1.44, 1.6, 1.76, 1.8800000000000001, 1.96, 2.16, 2.32, 2.44, 2.48, 2.6, 2.8000000000000003,
3.08, 3.2800000000000002, 3.4, 3.6, 3.8000000000000003, 4.08, 4.28, 4.32, 4.48, 4.64, 4.84, 4.88, 5.04, 5.12, 5.4, 5.5200000000000005, 5.68, 5.72, 5.88, 6.16, 6.36]
2022-07-06 21:47:54,929 INFO [offline_server.py:651] Disconnected: ('127.0.0.1', 48118). Number of connections: 0/10
```

For ease of reference, the above results are listed in the following table:

|word |CorentinJ/librispeech-alignments | this PR|
|---|---|---|
|AFTER| 0.36-0.73 | 0-0.28|
|EARLY|0.73-1.04| 0.28-0.88|
|NIGHTFALL|1.04-1.77|0.88-1.60|
|THE|1.77-1.90|1.60-1.76|
|YELLOW|1.90-2.16|1.76-2.16|
|LAMPS|2.16-2.59|2.16-2.60|
|WOULD|2.59-2.76|2.60-2.80|
|LIGHT|2.76-3.07|2.80-3.08|
|UP|3.07-3.27|3.08-3.28|
|HERE|3.27-3.52|3.28-3.60|
|AND|3.52-3.66|3.60-3.80|
|THERE|3.66-4.09|3.80-4.08|
|THE| 4.09-4.21|4.08-4.28|
|SQUALID|4.21-4.78|4.28-4.84|
|QUARTER|4.78-5.31|4.84-5.40|
|OF|5.31-5.42|5.40-5.52|
|THE|5.42-5.50|5.52-5.68|
|BROTHELS|5.50-6.16|5.68-6.36|
|silence| 6.16-6.625| N/A|

Since the model subsampling factor is 4 and frame shift is 0.01s, the resolution of the timestamp is 0.04s.

You can see that the predicted timestamps of the words in the middle of the utterance are very close to the one
from https://github.com/CorentinJ/librispeech-alignments

Also note that we are not doing force-alignment here. The words are decoded using greedy search and it happens that all words are predicted correctly.

