### PR TITLE
WIP feature: add easy interface api for simple task (and hf integration)

### DIFF
--- a/sherpa/python/sherpa/easy/__init__.py
+++ b/sherpa/python/sherpa/easy/__init__.py
@@ -1,0 +1,6 @@
+from .offline_asr import OfflineAsr
+
+try:
+    from .hf_api import get_hfconfig, model_from_hfconfig, transcribe_batch_from_tensor
+except ImportError:
+    pass

--- a/sherpa/python/sherpa/easy/decode.py
+++ b/sherpa/python/sherpa/easy/decode.py
@@ -1,0 +1,119 @@
+# Copyright      2022  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from typing import List
+
+import torch
+from sherpa import RnntConformerModel, greedy_search, modified_beam_search
+from torch.nn.utils.rnn import pad_sequence
+
+LOG_EPS = math.log(1e-10)
+
+
+@torch.no_grad()
+def run_model_and_do_greedy_search(
+    model: RnntConformerModel,
+    features: List[torch.Tensor],
+) -> List[List[int]]:
+    """Run RNN-T model with the given features and use greedy search
+    to decode the output of the model.
+
+    Args:
+      model:
+        The RNN-T model.
+      features:
+        A list of 2-D tensors. Each entry is of shape
+        (num_frames, feature_dim).
+    Returns:
+      Return a list-of-list containing the decoding token IDs.
+    """
+    features_length = torch.tensor(
+        [f.size(0) for f in features],
+        dtype=torch.int64,
+    )
+    features = pad_sequence(
+        features,
+        batch_first=True,
+        padding_value=LOG_EPS,
+    )
+
+    device = model.device
+    features = features.to(device)
+    features_length = features_length.to(device)
+
+    encoder_out, encoder_out_length = model.encoder(
+        features=features,
+        features_length=features_length,
+    )
+
+    hyp_tokens = greedy_search(
+        model=model,
+        encoder_out=encoder_out,
+        encoder_out_length=encoder_out_length.cpu(),
+    )
+    return hyp_tokens
+
+
+@torch.no_grad()
+def run_model_and_do_modified_beam_search(
+    model: RnntConformerModel,
+    features: List[torch.Tensor],
+    num_active_paths: int,
+) -> List[List[int]]:
+    """Run RNN-T model with the given features and use greedy search
+    to decode the output of the model.
+
+    Args:
+      model:
+        The RNN-T model.
+      features:
+        A list of 2-D tensors. Each entry is of shape
+        (num_frames, feature_dim).
+      num_active_paths:
+        Used only when decoding_method is modified_beam_search.
+        It specifies number of active paths for each utterance. Due to
+        merging paths with identical token sequences, the actual number
+        may be less than "num_active_paths".
+    Returns:
+      Return a list-of-list containing the decoding token IDs.
+    """
+    features_length = torch.tensor(
+        [f.size(0) for f in features],
+        dtype=torch.int64,
+    )
+    features = pad_sequence(
+        features,
+        batch_first=True,
+        padding_value=LOG_EPS,
+    )
+
+    device = model.device
+    features = features.to(device)
+    features_length = features_length.to(device)
+
+    encoder_out, encoder_out_length = model.encoder(
+        features=features,
+        features_length=features_length,
+    )
+
+    hyp_tokens = modified_beam_search(
+        model=model,
+        encoder_out=encoder_out,
+        encoder_out_length=encoder_out_length.cpu(),
+        num_active_paths=num_active_paths,
+    )
+    return hyp_tokens

--- a/sherpa/python/sherpa/easy/hf_api.py
+++ b/sherpa/python/sherpa/easy/hf_api.py
@@ -1,0 +1,58 @@
+import torch
+
+import sherpa
+from huggingface_hub import HfApi
+from huggingface_hub import hf_hub_url, cached_download, hf_hub_download
+from .offline_asr import OfflineAsr
+
+
+def get_hfconfig(model_id, config_name="hf_config"):
+    info = HfApi().model_info(repo_id=model_id)
+    if config_name is not None:
+        if config_name in info:
+            return info[config_name]
+        else:
+            raise ValueError("Config section " + config_name + " not found")
+    else:
+        return info
+
+
+def model_from_hfconfig(hf_repo, hf_config):
+    nn_model_filename = hf_hub_download(hf_repo, hf_config["nn_model_filename"])
+    token_filename = (
+        hf_hub_download(hf_repo, hf_config["token_filename"])
+        if "token_filename" in hf_config
+        else None
+    )
+    bpe_model_filename = (
+        hf_hub_download(hf_repo, hf_config["bpe_model_filename"])
+        if "bpe_model_filename" in hf_config
+        else None
+    )
+    decoding_method = hf_config["decoding_method"]
+    sample_rate = hf_config["sample_rate"]
+    num_active_paths = hf_config["num_active_paths"]
+
+    assert decoding_method in ("greedy_search", "modified_beam_search"), decoding_method
+
+    if decoding_method == "modified_beam_search":
+        assert num_active_paths >= 1, num_active_paths
+
+    if bpe_model_filename:
+        assert token_filename is None
+
+    if token_filename:
+        assert bpe_model_filename is None
+
+    return OfflineAsr(
+        nn_model_filename,
+        bpe_model_filename,
+        token_filename,
+        decoding_method,
+        num_active_paths,
+        sample_rate,
+    )
+
+
+def transcribe_batch_from_tensor(model, batch):
+    return model.decode_waves([batch])[0]

--- a/sherpa/python/sherpa/easy/offline_asr.py
+++ b/sherpa/python/sherpa/easy/offline_asr.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright      2022  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+from typing import List, Optional, Union
+
+import k2
+import kaldifeat
+import sentencepiece as spm
+import torch
+from sherpa import RnntConformerModel
+
+from .decode import (
+    run_model_and_do_greedy_search,
+    run_model_and_do_modified_beam_search,
+)
+
+
+class OfflineAsr(object):
+    def __init__(
+        self,
+        nn_model_filename: str,
+        bpe_model_filename: Optional[str],
+        token_filename: Optional[str],
+        decoding_method: str,
+        num_active_paths: int,
+        sample_rate: int = 16000,
+        device: Union[str, torch.device] = "cpu",
+    ):
+        """
+        Args:
+          nn_model_filename:
+            Path to the torch script model.
+          bpe_model_filename:
+            Path to the BPE model. If it is None, you have to provide
+            `token_filename`.
+          token_filename:
+            Path to tokens.txt. If it is None, you have to provide
+            `bpe_model_filename`.
+          decoding_method:
+            The decoding method to use. Currently, only greedy_search and
+            modified_beam_search are implemented.
+          num_active_paths:
+            Used only when decoding_method is modified_beam_search.
+            It specifies number of active paths for each utterance. Due to
+            merging paths with identical token sequences, the actual number
+            may be less than "num_active_paths".
+          sample_rate:
+            Expected sample rate of the feature extractor.
+          device:
+            The device to use for computation.
+        """
+        self.model = RnntConformerModel(
+            filename=nn_model_filename,
+            device=device,
+            optimize_for_inference=False,
+        )
+
+        if bpe_model_filename:
+            self.sp = spm.SentencePieceProcessor()
+            self.sp.load(bpe_model_filename)
+        else:
+            self.token_table = k2.SymbolTable.from_file(token_filename)
+
+        self.feature_extractor = self._build_feature_extractor(
+            sample_rate=sample_rate,
+            device=device,
+        )
+
+        assert decoding_method in (
+            "greedy_search",
+            "modified_beam_search",
+        ), decoding_method
+        if decoding_method == "greedy_search":
+            nn_and_decoding_func = run_model_and_do_greedy_search
+        elif decoding_method == "modified_beam_search":
+            nn_and_decoding_func = functools.partial(
+                run_model_and_do_modified_beam_search,
+                num_active_paths=num_active_paths,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported decoding_method: {decoding_method} "
+                "Please use greedy_search or modified_beam_search"
+            )
+
+        self.nn_and_decoding_func = nn_and_decoding_func
+        self.device = device
+
+    def _build_feature_extractor(
+        self,
+        sample_rate: int = 16000,
+        device: Union[str, torch.device] = "cpu",
+    ) -> kaldifeat.OfflineFeature:
+        """Build a fbank feature extractor for extracting features.
+
+        Args:
+          sample_rate:
+            Expected sample rate of the feature extractor.
+          device:
+            The device to use for computation.
+        Returns:
+          Return a fbank feature extractor.
+        """
+        opts = kaldifeat.FbankOptions()
+        opts.device = device
+        opts.frame_opts.dither = 0
+        opts.frame_opts.snip_edges = False
+        opts.frame_opts.samp_freq = sample_rate
+        opts.mel_opts.num_bins = 80
+
+        fbank = kaldifeat.Fbank(opts)
+
+        return fbank
+
+    def decode_waves(self, waves: List[torch.Tensor]) -> List[List[str]]:
+        """
+        Args:
+          waves:
+            A list of 1-D torch.float32 tensors containing audio samples.
+            wavs[i] contains audio samples for the i-th utterance.
+
+            Note:
+              Whether it should be in the range [-32768, 32767] or be normalized
+              to [-1, 1] depends on which range you used for your training data.
+              For instance, if your training data used [-32768, 32767],
+              then the given waves have to contain samples in this range.
+
+              All models trained in icefall use the normalized range [-1, 1].
+        Returns:
+          Return a list of decoded results. `ans[i]` contains the decoded
+          results for `wavs[i]`.
+        """
+        waves = [w.to(self.device) for w in waves]
+        features = self.feature_extractor(waves)
+
+        tokens = self.nn_and_decoding_func(self.model, features)
+
+        if hasattr(self, "sp"):
+            results = self.sp.decode(tokens)
+        else:
+            results = [[self.token_table[i] for i in hyp] for hyp in tokens]
+            results = ["".join(r) for r in results]
+
+        return results


### PR DESCRIPTION
@csukuangfj  this is just for comments -- might not even work/syntax or location of files might be completely wrong..

the idea is that we provide "easy" interface that would enable people to create the decoder or decode simple file just calling a few lines of code (similarly as kaldi binary tools usually just parse command line and call a single library function).
What do you think?
I propose this because having such a high level API would simplify the huggingface interface a lot -- look at 
https://github.com/huggingface/api-inference-community/blob/main/docker_images/speechbrain/app/pipelines/automatic_speech_recognition.py
(only a few calls of library function) and reduce code duplication perhaps.