### PR TITLE
Add fully kaldi-compatible parse-options.

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -66,10 +66,27 @@ jobs:
 
           python3 -m torch.utils.collect_env
 
+      - name: Cache kaldifeat
+        id: my-cache-2
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/tmp/kaldifeat
+          key: cache-tmp-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.torch }}
+
+      - name: Install kaldifeat
+        if: steps.my-cache-2.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          .github/scripts/install-kaldifeat.sh
 
       - name: Install sherpa
         shell: bash
         run: |
+          export KALDIFEAT_INSTALL_PREFIX=$HOME/tmp/kaldifeat/build
+          echo $KALDIFEAT_INSTALL_PREFIX
+          ls -lh $KALDIFEAT_INSTALL_PREFIX
+
           python3 setup.py install
 
       - name: Build doc

--- a/.github/workflows/run-cpp-test.yaml
+++ b/.github/workflows/run-cpp-test.yaml
@@ -48,6 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Display gcc version
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          gcc --version
+
+      - name: Display clang version
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          clang --version
+
       - name: Install PyTorch ${{ matrix.torch }}
         shell: bash
         if: startsWith(matrix.os, 'ubuntu')
@@ -105,6 +115,27 @@ jobs:
           ls -lh lib
           ls -lh bin
 
+      - name: Display dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        shell: bash
+        run: |
+          cd build
+
+          ldd lib/libsherpa_core.so
+
+          ldd bin/sherpa
+
+      - name: Display dependencies
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run: |
+          cd build
+
+          otool -L lib/libsherpa_core.dylib
+          otool -l lib/libsherpa_core.dylib
+
+          otool -L bin/sherpa
+          otool -l bin/sherpa
 
       - name: Test sherpa
         shell: bash

--- a/sherpa/csrc/CMakeLists.txt
+++ b/sherpa/csrc/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(sherpa_srcs
   hypothesis.cc
   log.cc
+  parse_options.cc
   rnnt_beam_search.cc
   rnnt_conformer_model.cc
   rnnt_conv_emformer_model.cc
@@ -22,6 +23,7 @@ if(SHERPA_ENABLE_TESTS)
   set(sherpa_test_srcs
     test_hypothesis.cc
     test_log.cc
+    test_parse_options.cc
   )
 
   function(sherpa_add_test source)

--- a/sherpa/csrc/parse_options.cc
+++ b/sherpa/csrc/parse_options.cc
@@ -1,0 +1,785 @@
+/**
+ * Copyright 2009-2011  Karel Vesely;  Microsoft Corporation;
+ *                      Saarland University (Author: Arnab Ghoshal);
+ * Copyright 2012-2013  Johns Hopkins University (Author: Daniel Povey);
+ *                      Frantisek Skala;  Arnab Ghoshal
+ * Copyright 2013       Tanel Alumae
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is copied and modified from kaldi/src/util/parse-options.cu
+
+#include "sherpa/csrc/parse_options.h"
+
+#include <ctype.h>
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <type_traits>
+#include <unordered_map>
+
+#include "sherpa/csrc/log.h"
+
+#ifdef _MSC_VER
+#define SHERPA_STRTOLL(cur_cstr, end_cstr) _strtoi64(cur_cstr, end_cstr, 10);
+#else
+#define SHERPA_STRTOLL(cur_cstr, end_cstr) strtoll(cur_cstr, end_cstr, 10);
+#endif
+
+namespace sherpa {
+
+/// Converts a string into an integer via strtoll and returns false if there was
+/// any kind of problem (i.e. the string was not an integer or contained extra
+/// non-whitespace junk, or the integer was too large to fit into the type it is
+/// being converted into).  Only sets *out if everything was OK and it returns
+/// true.
+template <class Int>
+bool ConvertStringToInteger(const std::string &str, Int *out) {
+  // copied from kaldi/src/util/text-util.h
+  static_assert(std::is_integral<Int>::value, "");
+  const char *this_str = str.c_str();
+  char *end = nullptr;
+  errno = 0;
+  int64_t i = SHERPA_STRTOLL(this_str, &end);
+  if (end != this_str) {
+    while (isspace(*end)) ++end;
+  }
+  if (end == this_str || *end != '\0' || errno != 0) return false;
+  Int iInt = static_cast<Int>(i);
+  if (static_cast<int64_t>(iInt) != i ||
+      (i < 0 && !std::numeric_limits<Int>::is_signed)) {
+    return false;
+  }
+  *out = iInt;
+  return true;
+}
+
+// copied from kaldi/src/util/text-util.cc
+template <class T>
+class NumberIstream {
+ public:
+  explicit NumberIstream(std::istream &i) : in_(i) {}
+
+  NumberIstream &operator>>(T &x) {
+    if (!in_.good()) return *this;
+    in_ >> x;
+    if (!in_.fail() && RemainderIsOnlySpaces()) return *this;
+    return ParseOnFail(&x);
+  }
+
+ private:
+  std::istream &in_;
+
+  bool RemainderIsOnlySpaces() {
+    if (in_.tellg() != std::istream::pos_type(-1)) {
+      std::string rem;
+      in_ >> rem;
+
+      if (rem.find_first_not_of(' ') != std::string::npos) {
+        // there is not only spaces
+        return false;
+      }
+    }
+
+    in_.clear();
+    return true;
+  }
+
+  NumberIstream &ParseOnFail(T *x) {
+    std::string str;
+    in_.clear();
+    in_.seekg(0);
+    // If the stream is broken even before trying
+    // to read from it or if there are many tokens,
+    // it's pointless to try.
+    if (!(in_ >> str) || !RemainderIsOnlySpaces()) {
+      in_.setstate(std::ios_base::failbit);
+      return *this;
+    }
+
+    std::unordered_map<std::string, T> inf_nan_map;
+    // we'll keep just uppercase values.
+    inf_nan_map["INF"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["+INF"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["-INF"] = -std::numeric_limits<T>::infinity();
+    inf_nan_map["INFINITY"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["+INFINITY"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["-INFINITY"] = -std::numeric_limits<T>::infinity();
+    inf_nan_map["NAN"] = std::numeric_limits<T>::quiet_NaN();
+    inf_nan_map["+NAN"] = std::numeric_limits<T>::quiet_NaN();
+    inf_nan_map["-NAN"] = -std::numeric_limits<T>::quiet_NaN();
+    // MSVC
+    inf_nan_map["1.#INF"] = std::numeric_limits<T>::infinity();
+    inf_nan_map["-1.#INF"] = -std::numeric_limits<T>::infinity();
+    inf_nan_map["1.#QNAN"] = std::numeric_limits<T>::quiet_NaN();
+    inf_nan_map["-1.#QNAN"] = -std::numeric_limits<T>::quiet_NaN();
+
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+
+    if (inf_nan_map.find(str) != inf_nan_map.end()) {
+      *x = inf_nan_map[str];
+    } else {
+      in_.setstate(std::ios_base::failbit);
+    }
+
+    return *this;
+  }
+};
+
+/// ConvertStringToReal converts a string into either float or double
+/// and returns false if there was any kind of problem (i.e. the string
+/// was not a floating point number or contained extra non-whitespace junk).
+/// Be careful- this function will successfully read inf's or nan's.
+template <typename T>
+bool ConvertStringToReal(const std::string &str, T *out) {
+  std::istringstream iss(str);
+
+  NumberIstream<T> i(iss);
+
+  i >> *out;
+
+  if (iss.fail()) {
+    // Number conversion failed.
+    return false;
+  }
+
+  return true;
+}
+
+ParseOptions::ParseOptions(const std::string &prefix, ParseOptions *po)
+    : print_args_(false), help_(false), usage_(""), argc_(0), argv_(nullptr) {
+  if (po != nullptr && po->other_parser_ != nullptr) {
+    // we get here if this constructor is used twice, recursively.
+    other_parser_ = po->other_parser_;
+  } else {
+    other_parser_ = po;
+  }
+  if (po != nullptr && po->prefix_ != "") {
+    prefix_ = po->prefix_ + std::string(".") + prefix;
+  } else {
+    prefix_ = prefix;
+  }
+}
+
+void ParseOptions::Register(const std::string &name, bool *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+void ParseOptions::Register(const std::string &name, int32_t *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+void ParseOptions::Register(const std::string &name, uint32_t *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+void ParseOptions::Register(const std::string &name, float *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+void ParseOptions::Register(const std::string &name, double *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+void ParseOptions::Register(const std::string &name, std::string *ptr,
+                            const std::string &doc) {
+  RegisterTmpl(name, ptr, doc);
+}
+
+// old-style, used for registering application-specific parameters
+template <typename T>
+void ParseOptions::RegisterTmpl(const std::string &name, T *ptr,
+                                const std::string &doc) {
+  if (other_parser_ == nullptr) {
+    this->RegisterCommon(name, ptr, doc, false);
+  } else {
+    SHERPA_CHECK(prefix_ != "")
+        << "prefix: " << prefix_ << "\n"
+        << "Cannot use empty prefix when registering with prefix.";
+    std::string new_name = prefix_ + '.' + name;  // name becomes prefix.name
+    other_parser_->Register(new_name, ptr, doc);
+  }
+}
+
+// does the common part of the job of registering a parameter
+template <typename T>
+void ParseOptions::RegisterCommon(const std::string &name, T *ptr,
+                                  const std::string &doc, bool is_standard) {
+  SHERPA_CHECK(ptr != nullptr);
+  std::string idx = name;
+  NormalizeArgName(&idx);
+  if (doc_map_.find(idx) != doc_map_.end()) {
+    SHERPA_LOG(WARNING) << "Registering option twice, ignoring second time: "
+                        << name;
+  } else {
+    this->RegisterSpecific(name, idx, ptr, doc, is_standard);
+  }
+}
+
+// used to register standard parameters (those that are present in all of the
+// applications)
+template <typename T>
+void ParseOptions::RegisterStandard(const std::string &name, T *ptr,
+                                    const std::string &doc) {
+  this->RegisterCommon(name, ptr, doc, true);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, bool *b,
+                                    const std::string &doc, bool is_standard) {
+  bool_map_[idx] = b;
+  doc_map_[idx] =
+      DocInfo(name, doc + " (bool, default = " + ((*b) ? "true)" : "false)"),
+              is_standard);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, int32_t *i,
+                                    const std::string &doc, bool is_standard) {
+  int_map_[idx] = i;
+  std::ostringstream ss;
+  ss << doc << " (int, default = " << *i << ")";
+  doc_map_[idx] = DocInfo(name, ss.str(), is_standard);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, uint32_t *u,
+                                    const std::string &doc, bool is_standard) {
+  uint_map_[idx] = u;
+  std::ostringstream ss;
+  ss << doc << " (uint, default = " << *u << ")";
+  doc_map_[idx] = DocInfo(name, ss.str(), is_standard);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, float *f,
+                                    const std::string &doc, bool is_standard) {
+  float_map_[idx] = f;
+  std::ostringstream ss;
+  ss << doc << " (float, default = " << *f << ")";
+  doc_map_[idx] = DocInfo(name, ss.str(), is_standard);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, double *f,
+                                    const std::string &doc, bool is_standard) {
+  double_map_[idx] = f;
+  std::ostringstream ss;
+  ss << doc << " (double, default = " << *f << ")";
+  doc_map_[idx] = DocInfo(name, ss.str(), is_standard);
+}
+
+void ParseOptions::RegisterSpecific(const std::string &name,
+                                    const std::string &idx, std::string *s,
+                                    const std::string &doc, bool is_standard) {
+  string_map_[idx] = s;
+  doc_map_[idx] =
+      DocInfo(name, doc + " (string, default = \"" + *s + "\")", is_standard);
+}
+
+void ParseOptions::DisableOption(const std::string &name) {
+  if (argv_ != nullptr) {
+    SHERPA_LOG(FATAL)
+        << "DisableOption must not be called after calling Read().";
+  }
+  if (doc_map_.erase(name) == 0) {
+    SHERPA_LOG(FATAL) << "Option " << name
+                      << " was not registered so cannot be disabled: ";
+  }
+  bool_map_.erase(name);
+  int_map_.erase(name);
+  uint_map_.erase(name);
+  float_map_.erase(name);
+  double_map_.erase(name);
+  string_map_.erase(name);
+}
+
+int ParseOptions::NumArgs() const { return positional_args_.size(); }
+
+std::string ParseOptions::GetArg(int i) const {
+  if (i < 1 || i > static_cast<int>(positional_args_.size())) {
+    SHERPA_LOG(FATAL) << "ParseOptions::GetArg, invalid index " << i;
+  }
+
+  return positional_args_[i - 1];
+}
+
+// We currently do not support any other options.
+enum ShellType { kBash = 0 };
+
+// This can be changed in the code if it ever does need to be changed (as it's
+// unlikely that one compilation of this tool-set would use both shells).
+static ShellType kShellType = kBash;
+
+// Returns true if we need to escape a string before putting it into
+// a shell (mainly thinking of bash shell, but should work for others)
+// This is for the convenience of the user so command-lines that are
+// printed out by ParseOptions::Read (with --print-args=true) are
+// paste-able into the shell and will run. If you use a different type of
+// shell, it might be necessary to change this function.
+// But it's mostly a cosmetic issue as it basically affects how
+// the program echoes its command-line arguments to the screen.
+static bool MustBeQuoted(const std::string &str, ShellType st) {
+  // Only Bash is supported (for the moment).
+  SHERPA_CHECK_EQ(st, kBash) << "Invalid shell type.";
+
+  const char *c = str.c_str();
+  if (*c == '\0') {
+    return true;  // Must quote empty string
+  } else {
+    const char *ok_chars[2];
+
+    // These seem not to be interpreted as long as there are no other "bad"
+    // characters involved (e.g. "," would be interpreted as part of something
+    // like a{b,c}, but not on its own.
+    ok_chars[kBash] = "[]~#^_-+=:.,/";
+
+    // Just want to make sure that a space character doesn't get automatically
+    // inserted here via an automated style-checking script, like it did before.
+    SHERPA_CHECK(!strchr(ok_chars[kBash], ' '));
+
+    for (; *c != '\0'; ++c) {
+      // For non-alphanumeric characters we have a list of characters which
+      // are OK. All others are forbidden (this is easier since the shell
+      // interprets most non-alphanumeric characters).
+      if (!isalnum(*c)) {
+        const char *d;
+        for (d = ok_chars[st]; *d != '\0'; ++d) {
+          if (*c == *d) break;
+        }
+        // If not alphanumeric or one of the "ok_chars", it must be escaped.
+        if (*d == '\0') return true;
+      }
+    }
+    return false;  // The string was OK. No quoting or escaping.
+  }
+}
+
+// Returns a quoted and escaped version of "str"
+// which has previously been determined to need escaping.
+// Our aim is to print out the command line in such a way that if it's
+// pasted into a shell of ShellType "st" (only bash for now), it
+// will get passed to the program in the same way.
+static std::string QuoteAndEscape(const std::string &str, ShellType st) {
+  // Only Bash is supported (for the moment).
+  SHERPA_CHECK_EQ(st, kBash) << "Invalid shell type.";
+
+  // For now we use the following rules:
+  // In the normal case, we quote with single-quote "'", and to escape
+  // a single-quote we use the string: '\'' (interpreted as closing the
+  // single-quote, putting an escaped single-quote from the shell, and
+  // then reopening the single quote).
+  char quote_char = '\'';
+  const char *escape_str = "'\\''";  // e.g. echo 'a'\''b' returns a'b
+
+  // If the string contains single-quotes that would need escaping this
+  // way, and we determine that the string could be safely double-quoted
+  // without requiring any escaping, then we double-quote the string.
+  // This is the case if the characters "`$\ do not appear in the string.
+  // e.g. see http://www.redhat.com/mirrors/LDP/LDP/abs/html/quotingvar.html
+  const char *c_str = str.c_str();
+  if (strchr(c_str, '\'') && !strpbrk(c_str, "\"`$\\")) {
+    quote_char = '"';
+    escape_str = "\\\"";  // should never be accessed.
+  }
+
+  char buf[2];
+  buf[1] = '\0';
+
+  buf[0] = quote_char;
+  std::string ans = buf;
+  const char *c = str.c_str();
+  for (; *c != '\0'; ++c) {
+    if (*c == quote_char) {
+      ans += escape_str;
+    } else {
+      buf[0] = *c;
+      ans += buf;
+    }
+  }
+  buf[0] = quote_char;
+  ans += buf;
+  return ans;
+}
+
+// static function
+std::string ParseOptions::Escape(const std::string &str) {
+  return MustBeQuoted(str, kShellType) ? QuoteAndEscape(str, kShellType) : str;
+}
+
+int ParseOptions::Read(int argc, const char *const argv[]) {
+  argc_ = argc;
+  argv_ = argv;
+  std::string key, value;
+  int i;
+
+  // first pass: look for config parameter, look for priority
+  for (i = 1; i < argc; ++i) {
+    if (std::strncmp(argv[i], "--", 2) == 0) {
+      if (std::strcmp(argv[i], "--") == 0) {
+        // a lone "--" marks the end of named options
+        break;
+      }
+      bool has_equal_sign;
+      SplitLongArg(argv[i], &key, &value, &has_equal_sign);
+      NormalizeArgName(&key);
+      Trim(&value);
+      if (key.compare("config") == 0) {
+        ReadConfigFile(value);
+      } else if (key.compare("help") == 0) {
+        PrintUsage();
+        exit(0);
+      }
+    }
+  }
+
+  bool double_dash_seen = false;
+  // second pass: add the command line options
+  for (i = 1; i < argc; ++i) {
+    if (std::strncmp(argv[i], "--", 2) == 0) {
+      if (std::strcmp(argv[i], "--") == 0) {
+        // A lone "--" marks the end of named options.
+        // Skip that option and break the processing of named options
+        i += 1;
+        double_dash_seen = true;
+        break;
+      }
+      bool has_equal_sign;
+      SplitLongArg(argv[i], &key, &value, &has_equal_sign);
+      NormalizeArgName(&key);
+      Trim(&value);
+      if (!SetOption(key, value, has_equal_sign)) {
+        PrintUsage(true);
+        SHERPA_LOG(FATAL) << "Invalid option " << argv[i];
+      }
+    } else {
+      break;
+    }
+  }
+
+  // process remaining arguments as positional
+  for (; i < argc; ++i) {
+    if ((std::strcmp(argv[i], "--") == 0) && !double_dash_seen) {
+      double_dash_seen = true;
+    } else {
+      positional_args_.push_back(std::string(argv[i]));
+    }
+  }
+
+  // if the user did not suppress this with --print-args = false....
+  if (print_args_) {
+    std::ostringstream strm;
+    for (int j = 0; j < argc; ++j) strm << Escape(argv[j]) << " ";
+    strm << '\n';
+    SHERPA_LOG(INFO) << strm.str();
+  }
+  return i;
+}
+
+void ParseOptions::PrintUsage(bool print_command_line /*=false*/) const {
+  std::ostringstream os;
+  os << '\n' << usage_ << '\n';
+  // first we print application-specific options
+  bool app_specific_header_printed = false;
+  for (auto it = doc_map_.begin(); it != doc_map_.end(); ++it) {
+    if (it->second.is_standard_ == false) {  // application-specific option
+      if (app_specific_header_printed == false) {  // header was not yet printed
+        os << "Options:" << '\n';
+        app_specific_header_printed = true;
+      }
+      os << "  --" << std::setw(25) << std::left << it->second.name_ << " : "
+         << it->second.use_msg_ << '\n';
+    }
+  }
+  if (app_specific_header_printed == true) {
+    os << '\n';
+  }
+
+  // then the standard options
+  os << "Standard options:" << '\n';
+  for (auto it = doc_map_.begin(); it != doc_map_.end(); ++it) {
+    if (it->second.is_standard_ == true) {  // we have standard option
+      os << "  --" << std::setw(25) << std::left << it->second.name_ << " : "
+         << it->second.use_msg_ << '\n';
+    }
+  }
+  os << '\n';
+  if (print_command_line) {
+    std::ostringstream strm;
+    strm << "Command line was: ";
+    for (int j = 0; j < argc_; ++j) strm << Escape(argv_[j]) << " ";
+    strm << '\n';
+    os << strm.str();
+  }
+
+  SHERPA_LOG(INFO) << os.str();
+}
+
+void ParseOptions::PrintConfig(std::ostream &os) const {
+  os << '\n' << "[[ Configuration of UI-Registered options ]]" << '\n';
+  std::string key;
+  for (auto it = doc_map_.begin(); it != doc_map_.end(); ++it) {
+    key = it->first;
+    os << it->second.name_ << " = ";
+    if (bool_map_.end() != bool_map_.find(key)) {
+      os << (*bool_map_.at(key) ? "true" : "false");
+    } else if (int_map_.end() != int_map_.find(key)) {
+      os << (*int_map_.at(key));
+    } else if (uint_map_.end() != uint_map_.find(key)) {
+      os << (*uint_map_.at(key));
+    } else if (float_map_.end() != float_map_.find(key)) {
+      os << (*float_map_.at(key));
+    } else if (double_map_.end() != double_map_.find(key)) {
+      os << (*double_map_.at(key));
+    } else if (string_map_.end() != string_map_.find(key)) {
+      os << "'" << *string_map_.at(key) << "'";
+    } else {
+      SHERPA_LOG(FATAL) << "PrintConfig: unrecognized option " << key
+                        << "[code error]";
+    }
+    os << '\n';
+  }
+  os << '\n';
+}
+
+void ParseOptions::ReadConfigFile(const std::string &filename) {
+  std::ifstream is(filename.c_str(), std::ifstream::in);
+  if (!is.good()) {
+    SHERPA_LOG(FATAL) << "Cannot open config file: " << filename;
+  }
+
+  std::string line, key, value;
+  int32_t line_number = 0;
+  while (std::getline(is, line)) {
+    ++line_number;
+    // trim out the comments
+    size_t pos;
+    if ((pos = line.find_first_of('#')) != std::string::npos) {
+      line.erase(pos);
+    }
+    // skip empty lines
+    Trim(&line);
+    if (line.length() == 0) continue;
+
+    if (line.substr(0, 2) != "--") {
+      SHERPA_LOG(FATAL)
+          << "Reading config file " << filename << ": line " << line_number
+          << " does not look like a line "
+          << "from a Kaldi command-line program's config file: should "
+          << "be of the form --x=y.  Note: config files intended to "
+          << "be sourced by shell scripts lack the '--'.";
+    }
+
+    // parse option
+    bool has_equal_sign;
+    SplitLongArg(line, &key, &value, &has_equal_sign);
+    NormalizeArgName(&key);
+    Trim(&value);
+    if (!SetOption(key, value, has_equal_sign)) {
+      PrintUsage(true);
+      SHERPA_LOG(FATAL) << "Invalid option " << line << " in config file "
+                        << filename << ": line " << line_number;
+    }
+  }
+}
+
+void ParseOptions::SplitLongArg(const std::string &in, std::string *key,
+                                std::string *value,
+                                bool *has_equal_sign) const {
+  SHERPA_CHECK(in.substr(0, 2) == "--") << in;  // precondition.
+  size_t pos = in.find_first_of('=', 0);
+  if (pos == std::string::npos) {  // we allow --option for bools
+    // defaults to empty.  We handle this differently in different cases.
+    *key = in.substr(2, in.size() - 2);  // 2 because starts with --.
+    *value = "";
+    *has_equal_sign = false;
+  } else if (pos == 2) {  // we also don't allow empty keys: --=value
+    PrintUsage(true);
+    SHERPA_LOG(FATAL) << "Invalid option (no key): " << in;
+  } else {                         // normal case: --option=value
+    *key = in.substr(2, pos - 2);  // 2 because starts with --.
+    *value = in.substr(pos + 1);
+    *has_equal_sign = true;
+  }
+}
+
+void ParseOptions::NormalizeArgName(std::string *str) const {
+  std::string out;
+  std::string::iterator it;
+
+  for (it = str->begin(); it != str->end(); ++it) {
+    if (*it == '_') {
+      out += '-';  // convert _ to -
+    } else {
+      out += std::tolower(*it);
+    }
+  }
+  *str = out;
+
+  SHERPA_CHECK_GT(str->length(), 0);
+}
+
+void ParseOptions::Trim(std::string *str) const {
+  const char *white_chars = " \t\n\r\f\v";
+
+  std::string::size_type pos = str->find_last_not_of(white_chars);
+  if (pos != std::string::npos) {
+    str->erase(pos + 1);
+    pos = str->find_first_not_of(white_chars);
+    if (pos != std::string::npos) str->erase(0, pos);
+  } else {
+    str->erase(str->begin(), str->end());
+  }
+}
+
+bool ParseOptions::SetOption(const std::string &key, const std::string &value,
+                             bool has_equal_sign) {
+  if (bool_map_.end() != bool_map_.find(key)) {
+    if (has_equal_sign && value == "") {
+      SHERPA_LOG(FATAL) << "Invalid option --" << key << "=";
+    }
+    *(bool_map_[key]) = ToBool(value);
+  } else if (int_map_.end() != int_map_.find(key)) {
+    *(int_map_[key]) = ToInt(value);
+  } else if (uint_map_.end() != uint_map_.find(key)) {
+    *(uint_map_[key]) = ToUint(value);
+  } else if (float_map_.end() != float_map_.find(key)) {
+    *(float_map_[key]) = ToFloat(value);
+  } else if (double_map_.end() != double_map_.find(key)) {
+    *(double_map_[key]) = ToDouble(value);
+  } else if (string_map_.end() != string_map_.find(key)) {
+    if (!has_equal_sign) {
+      SHERPA_LOG(FATAL) << "Invalid option --" << key
+                        << " (option format is --x=y).";
+    }
+    *(string_map_[key]) = value;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+bool ParseOptions::ToBool(std::string str) const {
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+
+  // allow "" as a valid option for "true", so that --x is the same as --x=true
+  if ((str.compare("true") == 0) || (str.compare("t") == 0) ||
+      (str.compare("1") == 0) || (str.compare("") == 0)) {
+    return true;
+  }
+  if ((str.compare("false") == 0) || (str.compare("f") == 0) ||
+      (str.compare("0") == 0)) {
+    return false;
+  }
+  // if it is neither true nor false:
+  PrintUsage(true);
+  SHERPA_LOG(FATAL)
+      << "Invalid format for boolean argument [expected true or false]: "
+      << str;
+  return false;  // never reached
+}
+
+int32_t ParseOptions::ToInt(const std::string &str) const {
+  int32_t ret;
+  if (!ConvertStringToInteger(str, &ret))
+    SHERPA_LOG(FATAL) << "Invalid integer option \"" << str << "\"";
+  return ret;
+}
+
+uint32_t ParseOptions::ToUint(const std::string &str) const {
+  uint32_t ret;
+  if (!ConvertStringToInteger(str, &ret))
+    SHERPA_LOG(FATAL) << "Invalid integer option \"" << str << "\"";
+  return ret;
+}
+
+float ParseOptions::ToFloat(const std::string &str) const {
+  float ret;
+  if (!ConvertStringToReal(str, &ret))
+    SHERPA_LOG(FATAL) << "Invalid floating-point option \"" << str << "\"";
+  return ret;
+}
+
+double ParseOptions::ToDouble(const std::string &str) const {
+  double ret;
+  if (!ConvertStringToReal(str, &ret))
+    SHERPA_LOG(FATAL) << "Invalid floating-point option \"" << str << "\"";
+  return ret;
+}
+
+// instantiate templates
+template void ParseOptions::RegisterTmpl(const std::string &name, bool *ptr,
+                                         const std::string &doc);
+template void ParseOptions::RegisterTmpl(const std::string &name, int32_t *ptr,
+                                         const std::string &doc);
+template void ParseOptions::RegisterTmpl(const std::string &name, uint32_t *ptr,
+                                         const std::string &doc);
+template void ParseOptions::RegisterTmpl(const std::string &name, float *ptr,
+                                         const std::string &doc);
+template void ParseOptions::RegisterTmpl(const std::string &name, double *ptr,
+                                         const std::string &doc);
+template void ParseOptions::RegisterTmpl(const std::string &name,
+                                         std::string *ptr,
+                                         const std::string &doc);
+
+template void ParseOptions::RegisterStandard(const std::string &name, bool *ptr,
+                                             const std::string &doc);
+template void ParseOptions::RegisterStandard(const std::string &name,
+                                             int32_t *ptr,
+                                             const std::string &doc);
+template void ParseOptions::RegisterStandard(const std::string &name,
+                                             uint32_t *ptr,
+                                             const std::string &doc);
+template void ParseOptions::RegisterStandard(const std::string &name,
+                                             float *ptr,
+                                             const std::string &doc);
+template void ParseOptions::RegisterStandard(const std::string &name,
+                                             double *ptr,
+                                             const std::string &doc);
+template void ParseOptions::RegisterStandard(const std::string &name,
+                                             std::string *ptr,
+                                             const std::string &doc);
+
+template void ParseOptions::RegisterCommon(const std::string &name, bool *ptr,
+                                           const std::string &doc,
+                                           bool is_standard);
+template void ParseOptions::RegisterCommon(const std::string &name,
+                                           int32_t *ptr, const std::string &doc,
+                                           bool is_standard);
+template void ParseOptions::RegisterCommon(const std::string &name,
+                                           uint32_t *ptr,
+                                           const std::string &doc,
+                                           bool is_standard);
+template void ParseOptions::RegisterCommon(const std::string &name, float *ptr,
+                                           const std::string &doc,
+                                           bool is_standard);
+template void ParseOptions::RegisterCommon(const std::string &name, double *ptr,
+                                           const std::string &doc,
+                                           bool is_standard);
+template void ParseOptions::RegisterCommon(const std::string &name,
+                                           std::string *ptr,
+                                           const std::string &doc,
+                                           bool is_standard);
+
+}  // namespace sherpa

--- a/sherpa/csrc/parse_options.h
+++ b/sherpa/csrc/parse_options.h
@@ -1,0 +1,268 @@
+/**
+ * Copyright 2009-2011  Karel Vesely;  Microsoft Corporation;
+ *                      Saarland University (Author: Arnab Ghoshal);
+ * Copyright 2012-2013  Frantisek Skala;  Arnab Ghoshal
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is copied and modified from kaldi/src/util/parse-options.h
+
+#ifndef SHERPA_CSRC_PARSE_OPTIONS_H_
+#define SHERPA_CSRC_PARSE_OPTIONS_H_
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace sherpa {
+
+class ParseOptions {
+ public:
+  explicit ParseOptions(const char *usage)
+      : print_args_(true),
+        help_(false),
+        usage_(usage),
+        argc_(0),
+        argv_(nullptr),
+        prefix_(""),
+        other_parser_(nullptr) {
+#if !defined(_MSC_VER) && !defined(__CYGWIN__)
+    // This is just a convenient place to set the stderr to line
+    // buffering mode, since it's called at program start.
+    // This helps ensure different programs' output is not mixed up.
+    setlinebuf(stderr);
+#endif
+    RegisterStandard("config", &config_,
+                     "Configuration file to read (this "
+                     "option may be repeated)");
+    RegisterStandard("print-args", &print_args_,
+                     "Print the command line arguments (to stderr)");
+    RegisterStandard("help", &help_, "Print out usage message");
+  }
+
+  /**
+    This is a constructor for the special case where some options are
+    registered with a prefix to avoid conflicts.  The object thus created will
+    only be used temporarily to register an options class with the original
+    options parser (which is passed as the *other pointer) using the given
+    prefix.  It should not be used for any other purpose, and the prefix must
+    not be the empty string.  It seems to be the least bad way of implementing
+    options with prefixes at this point.
+    Example of usage is:
+     ParseOptions po;  // original ParseOptions object
+     ParseOptions po_mfcc("mfcc", &po); // object with prefix.
+     MfccOptions mfcc_opts;
+     mfcc_opts.Register(&po_mfcc);
+    The options will now get registered as, e.g., --mfcc.frame-shift=10.0
+    instead of just --frame-shift=10.0
+   */
+  ParseOptions(const std::string &prefix, ParseOptions *other);
+
+  ParseOptions(const ParseOptions &) = delete;
+  ParseOptions &operator=(const ParseOptions &) = delete;
+  ~ParseOptions() = default;
+
+  void Register(const std::string &name, bool *ptr, const std::string &doc);
+  void Register(const std::string &name, int32_t *ptr, const std::string &doc);
+  void Register(const std::string &name, uint32_t *ptr, const std::string &doc);
+  void Register(const std::string &name, float *ptr, const std::string &doc);
+  void Register(const std::string &name, double *ptr, const std::string &doc);
+  void Register(const std::string &name, std::string *ptr,
+                const std::string &doc);
+
+  /// If called after registering an option and before calling
+  /// Read(), disables that option from being used.  Will crash
+  /// at runtime if that option had not been registered.
+  void DisableOption(const std::string &name);
+
+  /// This one is used for registering standard parameters of all the programs
+  template <typename T>
+  void RegisterStandard(const std::string &name, T *ptr,
+                        const std::string &doc);
+
+  /**
+    Parses the command line options and fills the ParseOptions-registered
+    variables. This must be called after all the variables were registered!!!
+
+    Initially the variables have implicit values,
+    then the config file values are set-up,
+    finally the command line values given.
+    Returns the first position in argv that was not used.
+    [typically not useful: use NumParams() and GetParam(). ]
+   */
+  int Read(int argc, const char *const *argv);
+
+  /// Prints the usage documentation [provided in the constructor].
+  void PrintUsage(bool print_command_line = false) const;
+
+  /// Prints the actual configuration of all the registered variables
+  void PrintConfig(std::ostream &os) const;
+
+  /// Reads the options values from a config file.  Must be called after
+  /// registering all options.  This is usually used internally after the
+  /// standard --config option is used, but it may also be called from a
+  /// program.
+  void ReadConfigFile(const std::string &filename);
+
+  /// Number of positional parameters (c.f. argc-1).
+  int NumArgs() const;
+
+  /// Returns one of the positional parameters; 1-based indexing for argc/argv
+  /// compatibility. Will crash if param is not >=1 and <=NumArgs().
+  ///
+  /// Note: Index is 1 based.
+  std::string GetArg(int param) const;
+
+  std::string GetOptArg(int param) const {
+    return (param <= NumArgs() ? GetArg(param) : "");
+  }
+
+  /// The following function will return a possibly quoted and escaped
+  /// version of "str", according to the current shell.  Currently
+  /// this is just hardwired to bash.  It's useful for debug output.
+  static std::string Escape(const std::string &str);
+
+ private:
+  /// Template to register various variable types,
+  /// used for program-specific parameters
+  template <typename T>
+  void RegisterTmpl(const std::string &name, T *ptr, const std::string &doc);
+
+  // Following functions do just the datatype-specific part of the job
+  /// Register boolean variable
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        bool *b, const std::string &doc, bool is_standard);
+  /// Register int32_t variable
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        int32_t *i, const std::string &doc, bool is_standard);
+  /// Register unsigned  int32_t variable
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        uint32_t *u, const std::string &doc, bool is_standard);
+  /// Register float variable
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        float *f, const std::string &doc, bool is_standard);
+  /// Register double variable [useful as we change BaseFloat type].
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        double *f, const std::string &doc, bool is_standard);
+  /// Register string variable
+  void RegisterSpecific(const std::string &name, const std::string &idx,
+                        std::string *s, const std::string &doc,
+                        bool is_standard);
+
+  /// Does the actual job for both kinds of parameters
+  /// Does the common part of the job for all datatypes,
+  /// then calls RegisterSpecific
+  template <typename T>
+  void RegisterCommon(const std::string &name, T *ptr, const std::string &doc,
+                      bool is_standard);
+
+  /// Set option with name "key" to "value"; will crash if can't do it.
+  /// "has_equal_sign" is used to allow --x for a boolean option x,
+  /// and --y=, for a string option y.
+  bool SetOption(const std::string &key, const std::string &value,
+                 bool has_equal_sign);
+
+  bool ToBool(std::string str) const;
+  int32_t ToInt(const std::string &str) const;
+  uint32_t ToUint(const std::string &str) const;
+  float ToFloat(const std::string &str) const;
+  double ToDouble(const std::string &str) const;
+
+  // maps for option variables
+  std::unordered_map<std::string, bool *> bool_map_;
+  std::unordered_map<std::string, int32_t *> int_map_;
+  std::unordered_map<std::string, uint32_t *> uint_map_;
+  std::unordered_map<std::string, float *> float_map_;
+  std::unordered_map<std::string, double *> double_map_;
+  std::unordered_map<std::string, std::string *> string_map_;
+
+  /**
+     Structure for options' documentation
+   */
+  struct DocInfo {
+    DocInfo() = default;
+    DocInfo(const std::string &name, const std::string &usemsg)
+        : name_(name), use_msg_(usemsg), is_standard_(false) {}
+    DocInfo(const std::string &name, const std::string &usemsg,
+            bool is_standard)
+        : name_(name), use_msg_(usemsg), is_standard_(is_standard) {}
+
+    std::string name_;
+    std::string use_msg_;
+    bool is_standard_;
+  };
+  using DocMapType = std::unordered_map<std::string, DocInfo>;
+  DocMapType doc_map_;  ///< map for the documentation
+
+  bool print_args_;     ///< variable for the implicit --print-args parameter
+  bool help_;           ///< variable for the implicit --help parameter
+  std::string config_;  ///< variable for the implicit --config parameter
+  std::vector<std::string> positional_args_;
+  const char *usage_;
+  int argc_;
+  const char *const *argv_;
+
+  /// These members are not normally used. They are only used when the object
+  /// is constructed with a prefix
+  std::string prefix_;
+  ParseOptions *other_parser_;
+
+ protected:
+  /// SplitLongArg parses an argument of the form --a=b, --a=, or --a,
+  /// and sets "has_equal_sign" to true if an equals-sign was parsed..
+  /// this is needed in order to correctly allow --x for a boolean option
+  /// x, and --y= for a string option y, and to disallow --x= and --y.
+  void SplitLongArg(const std::string &in, std::string *key, std::string *value,
+                    bool *has_equal_sign) const;
+
+  void NormalizeArgName(std::string *str) const;
+
+  /// Removes the beginning and trailing whitespaces from a string
+  void Trim(std::string *str) const;
+};
+
+/// This template is provided for convenience in reading config classes from
+/// files; this is not the standard way to read configuration options, but may
+/// occasionally be needed.  This function assumes the config has a function
+/// "void Register(ParseOptions *opts)" which it can call to register the
+/// ParseOptions object.
+template <class C>
+void ReadConfigFromFile(const std::string &config_filename, C *c) {
+  std::ostringstream usage_str;
+  usage_str << "Parsing config from "
+            << "from '" << config_filename << "'";
+  ParseOptions po(usage_str.str().c_str());
+  c->Register(&po);
+  po.ReadConfigFile(config_filename);
+}
+
+/// This variant of the template ReadConfigFromFile is for if you need to read
+/// two config classes from the same file.
+template <class C1, class C2>
+void ReadConfigsFromFile(const std::string &conf, C1 *c1, C2 *c2) {
+  std::ostringstream usage_str;
+  usage_str << "Parsing config from "
+            << "from '" << conf << "'";
+  ParseOptions po(usage_str.str().c_str());
+  c1->Register(&po);
+  c2->Register(&po);
+  po.ReadConfigFile(conf);
+}
+
+}  // namespace sherpa
+
+#endif  // SHERPA_CSRC_PARSE_OPTIONS_H_

--- a/sherpa/csrc/test_parse_options.cc
+++ b/sherpa/csrc/test_parse_options.cc
@@ -1,0 +1,302 @@
+/**
+ * Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+
+#include "gtest/gtest.h"
+#include "sherpa/csrc/parse_options.h"
+
+namespace sherpa {
+
+struct MyOptions {
+  bool b = false;
+  int32_t i32 = 1;
+  uint32_t u32 = 2;
+  float f = 3;
+  double d = 4;
+  std::string s;
+
+  void Register(ParseOptions *po) {
+    po->Register("my-bool", &b, "A bool variable in MyOptions.");
+    po->Register("my-i32", &i32, "An int32 variable in MyOptions.");
+
+    po->Register("my-u32", &u32, "An uint32 variable in MyOptions.");
+
+    po->Register("my-f", &f, "A float variable in MyOptions.");
+
+    po->Register("my-d", &d, "A double variable in MyOptions.");
+
+    po->Register("my-s", &s, "A string variable in MyOptions.");
+  }
+};
+
+TEST(ParseOptions, FromCommandline) {
+  int32_t a;
+  double d;
+  const char *const argv[] = {"./a.out",      "--my-bool=1", "--my-i32=100",
+                              "--my-u32=8",   "--my-f=0.5",  "--my-d=1.5",
+                              "--my-s=hello", "--a=3",       "--d=-1.25",
+                              "--print-args", "foo",         "bar"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  ParseOptions po("Test parsing from the commandline");
+  MyOptions opts;
+  opts.Register(&po);
+  po.Register("a", &a, "An integer variable");
+  po.Register("d", &d, "A double variable");
+  po.Read(argc, argv);
+
+  EXPECT_EQ(a, 3);
+  EXPECT_EQ(d, -1.25);
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, 100);
+  EXPECT_EQ(opts.u32, 8);
+  EXPECT_EQ(opts.f, 0.5);
+  EXPECT_EQ(opts.d, 1.5);
+  EXPECT_EQ(opts.s, "hello");
+
+  EXPECT_EQ(po.NumArgs(), 2);
+  EXPECT_EQ(po.GetArg(1), "foo");  // Note: index starts from 1, not 0!
+  EXPECT_EQ(po.GetArg(2), "bar");
+}
+
+TEST(ParseOptions, FromCommandlineWithPrefix) {
+  int32_t a;
+  double d;
+  const char *const argv[] = {"./a.out",
+                              "--print-args",
+                              "--sherpa.my-bool=1",
+                              "--sherpa.my-i32=100",
+                              "--sherpa.my-u32=8",
+                              "--sherpa.my-f=0.5",
+                              "--sherpa.my-d=1.5",
+                              "--sherpa.my-s=hello",
+                              "--a=3",
+                              "--d=-1.25",
+                              "foo",
+                              "bar"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  ParseOptions po("Test parsing from the commandline with prefix");
+  ParseOptions po2("sherpa", &po);
+  MyOptions opts;
+  opts.Register(&po2);
+  po.Register("a", &a, "An integer variable");
+  po.Register("d", &d, "A double variable");
+  po.Read(argc, argv);
+
+  EXPECT_EQ(a, 3);
+  EXPECT_EQ(d, -1.25);
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, 100);
+  EXPECT_EQ(opts.u32, 8);
+  EXPECT_EQ(opts.f, 0.5);
+  EXPECT_EQ(opts.d, 1.5);
+  EXPECT_EQ(opts.s, "hello");
+
+  EXPECT_EQ(po.NumArgs(), 2);
+  EXPECT_EQ(po.GetArg(1), "foo");
+  EXPECT_EQ(po.GetArg(2), "bar");
+}
+
+TEST(ParseOptions, FromCommandlineWithTwoPrefixes) {
+  int32_t a;
+  double d;
+  const char *const argv[] = {"./a.out",
+                              "--print-args",
+                              "--sherpa.torch.my-bool=1",
+                              "--sherpa.torch.my-i32=100",
+                              "--sherpa.torch.my-u32=8",
+                              "--sherpa.torch.my-f=0.5",
+                              "--sherpa.torch.my-d=1.5",
+                              "--sherpa.torch.my-s=hello",
+                              "--a=3",
+                              "--d=-1.25",
+                              "foo",
+                              "bar"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  ParseOptions po("Test parsing from the commandline with two prefixes");
+  ParseOptions po2("sherpa", &po);
+  ParseOptions po3("torch", &po2);
+  MyOptions opts;
+  opts.Register(&po3);
+  po.Register("a", &a, "An integer variable");
+  po.Register("d", &d, "A double variable");
+  po.Read(argc, argv);
+
+  EXPECT_EQ(a, 3);
+  EXPECT_EQ(d, -1.25);
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, 100);
+  EXPECT_EQ(opts.u32, 8);
+  EXPECT_EQ(opts.f, 0.5);
+  EXPECT_EQ(opts.d, 1.5);
+  EXPECT_EQ(opts.s, "hello");
+
+  EXPECT_EQ(po.NumArgs(), 2);
+  EXPECT_EQ(po.GetArg(1), "foo");
+  EXPECT_EQ(po.GetArg(2), "bar");
+}
+
+TEST(ParseOptions, ParseHelp) {
+  const char *const argv[] = {"./a.out", "--help"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+
+  ParseOptions po("Parse help");
+  MyOptions opts;
+  opts.Register(&po);
+
+  EXPECT_EXIT(po.Read(argc, argv), testing::ExitedWithCode(0), "");
+}
+
+TEST(ParseOptions, ParseFromFile) {
+  std::string filename = "my-options-for-parse-options.txt";
+  {
+    std::ofstream of(filename);
+
+    of << "--my-bool=1\n";
+    of << "--my-i32=-100\n";
+    of << "--my-s=hello\n";
+  }
+
+  const char *const argv[] = {
+      "./a.out",      "--config=my-options-for-parse-options.txt",
+      "--my-u32=8",   "--my-f=0.5",
+      "--my-d=1.5",   "--my-s=world",
+      "--print-args", "foo",
+      "bar"};
+
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  ParseOptions po("Test parsing from the commandline and config file");
+
+  MyOptions opts;
+  opts.Register(&po);
+
+  po.Read(argc, argv);
+
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, -100);
+  EXPECT_EQ(opts.u32, 8);
+  EXPECT_EQ(opts.f, 0.5);
+  EXPECT_EQ(opts.d, 1.5);
+  EXPECT_EQ(opts.s, "world");  // commandline options have a higher priority
+
+  remove(filename.c_str());
+}
+
+TEST(ParseOptions, ParseFromMultipleFiles) {
+  std::string filename1 = "my-options-for-parse-options1.txt";
+  std::string filename2 = "my-options-for-parse-options2.txt";
+  {
+    std::ofstream of(filename1);
+
+    of << "--my-bool=1\n";
+    of << "--my-i32=-100\n";
+  }
+
+  {
+    std::ofstream of(filename2);
+
+    of << "--my-s=hello\n";
+  }
+
+  const char *const argv[] = {"./a.out",
+                              "--config=my-options-for-parse-options1.txt",
+                              "--config=my-options-for-parse-options2.txt",
+                              "--my-u32=8",
+                              "--my-f=0.5",
+                              "--my-d=1.5",
+                              "--print-args",
+                              "foo",
+                              "bar"};
+
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  ParseOptions po("Test parsing from the commandline and config files");
+
+  MyOptions opts;
+  opts.Register(&po);
+
+  po.Read(argc, argv);
+
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, -100);
+  EXPECT_EQ(opts.u32, 8);
+  EXPECT_EQ(opts.f, 0.5);
+  EXPECT_EQ(opts.d, 1.5);
+  EXPECT_EQ(opts.s, "hello");
+
+  remove(filename1.c_str());
+  remove(filename2.c_str());
+}
+
+TEST(ParseOptions, Duplicates) {
+  int32_t a = 10;
+  int32_t b = 20;
+  ParseOptions po("Test duplicates");
+  po.Register("i", &a, "My integer option");
+  po.Register("i", &b, "My integer option");
+  // The second one is ignored
+  const char *const argv[] = {"./a.out", "--i=3"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+  po.Read(argc, argv);
+
+  EXPECT_EQ(a, 3);
+  EXPECT_EQ(b, 20);
+  EXPECT_EQ(po.NumArgs(), 0);
+}
+
+TEST(ParseOptions, DoubleDash) {
+  int32_t a = 10;
+
+  const char *const argv[] = {"./a.out", "--i=3", "--", "--foo=bar", "baz"};
+  int32_t argc = sizeof(argv) / sizeof(argv[0]);
+
+  ParseOptions po("Test double dash");
+  po.Register("i", &a, "My integer option");
+  po.Read(argc, argv);
+
+  EXPECT_EQ(a, 3);
+  EXPECT_EQ(po.NumArgs(), 2);
+  EXPECT_EQ(po.GetArg(1), "--foo=bar");
+  EXPECT_EQ(po.GetArg(2), "baz");
+}
+
+TEST(ReadConfigFromFile, OneOption) {
+  std::string filename = "my-options-for-parse-options.txt";
+  {
+    std::ofstream of(filename);
+
+    of << "--my-bool=1\n";
+    of << "--my-i32=-100\n";
+    of << "--my-u32=1000\n";
+    of << "--my-f=-0.5\n";
+    of << "--my-d=3.5\n";
+    of << "--my-s=hello world\n";
+  }
+  MyOptions opts;
+  ReadConfigFromFile(filename, &opts);
+
+  EXPECT_EQ(opts.b, true);
+  EXPECT_EQ(opts.i32, -100);
+  EXPECT_EQ(opts.u32, 1000);
+  EXPECT_EQ(opts.f, -0.5);
+  EXPECT_EQ(opts.d, 3.5);
+  EXPECT_EQ(opts.s, "hello world");
+
+  remove(filename.c_str());
+}
+
+}  // namespace sherpa


### PR DESCRIPTION
The C++ code is copied/modifed from Kaldi so that users can use their existing kaldi-style config files to pass options
to sherpa in the future.