### PR TITLE
add warmup for torchscript models

### DIFF
--- a/sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py
+++ b/sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py
@@ -280,6 +280,27 @@ class StreamingServer(object):
 
         self.current_active_connections = 0
 
+    async def warmup(self) -> None:
+        """Do warmup to the torchscript model to decrease the waiting time
+        of the first request.
+
+        See https://github.com/k2-fsa/sherpa/pull/100 for details
+        """
+        logging.info("Warmup start")
+        stream = Stream(
+            context_size=self.context_size,
+            initial_states=self.initial_states,
+        )
+        self.beam_search.init_stream(stream)
+
+        samples = torch.rand(16000 * 1, dtype=torch.float32)  # 1 second
+        stream.accept_waveform(sampling_rate=16000, waveform=samples)
+
+        while len(stream.features) > self.chunk_length_pad:
+            await self.compute_and_decode(stream)
+
+        logging.info("Warmup done")
+
     async def stream_consumer_task(self):
         """This function extracts streams from the queue, batches them up, sends
         them to the RNN-T model for computation and decoding.
@@ -350,6 +371,7 @@ class StreamingServer(object):
 
     async def run(self, port: int):
         task = asyncio.create_task(self.stream_consumer_task())
+        await self.warmup()
 
         async with websockets.serve(
             self.handle_connection,

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
@@ -283,6 +283,27 @@ class StreamingServer(object):
 
         self.current_active_connections = 0
 
+    async def warmup(self) -> None:
+        """Do warmup to the torchscript model to decrease the waiting time
+        of the first request.
+
+        See https://github.com/k2-fsa/sherpa/pull/100 for details
+        """
+        logging.info("Warmup start")
+        stream = Stream(
+            context_size=self.context_size,
+            initial_states=self.initial_states,
+        )
+        self.beam_search.init_stream(stream)
+
+        samples = torch.rand(16000 * 1, dtype=torch.float32)  # 1 second
+        stream.accept_waveform(sampling_rate=16000, waveform=samples)
+
+        while len(stream.features) > self.chunk_length:
+            await self.compute_and_decode(stream)
+
+        logging.info("Warmup done")
+
     async def stream_consumer_task(self):
         """This function extracts streams from the queue, batches them up, sends
         them to the RNN-T model for computation and decoding.
@@ -353,6 +374,7 @@ class StreamingServer(object):
 
     async def run(self, port: int):
         task = asyncio.create_task(self.stream_consumer_task())
+        await self.warmup()
 
         async with websockets.serve(
             self.handle_connection,

--- a/sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py
+++ b/sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py
@@ -324,6 +324,11 @@ class StreamingServer(object):
         self.current_active_connections = 0
 
     async def warmup(self) -> None:
+        """Do warmup to the torchscript model to decrease the waiting time
+        of the first request.
+
+        See https://github.com/k2-fsa/sherpa/pull/100 for details
+        """
         logging.info("Warmup start")
         stream = Stream(
             context_size=self.context_size,
@@ -331,7 +336,7 @@ class StreamingServer(object):
         )
         self.beam_search.init_stream(stream)
 
-        samples = torch.rand(16000 * 30, dtype=torch.float32)  # 30 seconds
+        samples = torch.rand(16000 * 1, dtype=torch.float32)  # 1 second
         stream.accept_waveform(sampling_rate=16000, waveform=samples)
 
         while len(stream.features) > self.chunk_length:


### PR DESCRIPTION
See also
- https://github.com/pytorch/pytorch/issues/33354
- https://github.com/k2-fsa/sherpa/issues/90#issuecomment-1213367704


The following experiments show that we can decrease the waiting time of the first request by using warmup.

## Before this PR
### First run of the client
The client waits for about 6 seconds to get a reply after sending the data.
```
2022-08-22 13:08:37,472 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:08:43,094 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:08:43,153 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:08:43,186 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:08:43,220 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

### Second run of the client
The client waits for about 0.5 seconds for the second run.
```
2022-08-22 13:08:47,332 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:08:47,896 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:08:48,147 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:08:48,406 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:08:48,665 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

### Third run of the client
The client also waits for about 0.5 seconds for the third run.
```
2022-08-22 13:08:57,042 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:08:57,599 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:08:57,858 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:08:58,116 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:08:58,374 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

## With this PR
### First run
The client waits for about 0.5 seconds to get a reply after sending the data.
```
2022-08-22 13:16:01,033 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:16:01,593 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:16:01,886 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:16:02,118 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:16:02,367 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

### Second run
It waits for about 0.5 seconds for the second run.
```
2022-08-22 13:17:41,191 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:17:41,748 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:17:42,007 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:17:42,271 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:17:42,526 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

### Third run
It takes about 0.5 seconds for the third run.
```
2022-08-22 13:17:50,565 INFO [streaming_client.py:88] Sending /ceph-fj/fangjun/open-source-2/icefall-models/icefall-asr-librispeech-p
runed-stateless-emformer-rnnt2-2022-06-01/test_wavs/1089-134686-0001.wav
2022-08-22 13:17:51,119 INFO [streaming_client.py:79] Partial result (last 20 words):
2022-08-22 13:17:51,380 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER
2022-08-22 13:17:51,638 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EAR
2022-08-22 13:17:51,897 INFO [streaming_client.py:79] Partial result (last 20 words): AFTER EARLY
```

----

