### PR TITLE
Fix compiling with kaldi-native-io

### DIFF
--- a/.github/workflows/run-cpp-test.yaml
+++ b/.github/workflows/run-cpp-test.yaml
@@ -110,7 +110,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
-          make -j VERBOSE=1
+          make -j2 VERBOSE=1
 
           ls -lh lib
           ls -lh bin

--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import shutil
 import sys
 from pathlib import Path
 
@@ -56,6 +57,9 @@ class BuildExtension(build_ext):
         # build/lib.linux-x86_64-3.8
         os.makedirs(self.build_lib, exist_ok=True)
 
+        out_bin_dir = Path(self.build_lib).parent / "sherpa" / "bin"
+        install_dir = Path(self.build_lib).resolve() / "sherpa"
+
         sherpa_dir = Path(__file__).parent.parent.resolve()
 
         cmake_args = os.environ.get("SHERPA_CMAKE_ARGS", "")
@@ -66,7 +70,7 @@ class BuildExtension(build_ext):
             cmake_args = "-DCMAKE_BUILD_TYPE=Release"
 
         extra_cmake_args = " -DSHERPA_ENABLE_TESTS=OFF "
-        extra_cmake_args += f" -DCMAKE_INSTALL_PREFIX={Path(self.build_lib).resolve()}/sherpa "  # noqa
+        extra_cmake_args += f" -DCMAKE_INSTALL_PREFIX={install_dir} "  # noqa
 
         if "PYTHON_EXECUTABLE" not in cmake_args:
             print(f"Setting PYTHON_EXECUTABLE to {sys.executable}")
@@ -77,9 +81,6 @@ class BuildExtension(build_ext):
         if is_windows():
             build_cmd = f"""
          cmake {cmake_args} -B {self.build_temp} -S {sherpa_dir}
-         cmake --build {self.build_temp} --target sherpa --config Release -- -m
-  cmake --build {self.build_temp} --target sherpa-version --config Release -- -m
-         cmake --build {self.build_temp} --target _sherpa --config Release -- -m
          cmake --build {self.build_temp} --target install --config Release -- -m
             """
             print(f"build command is:\n{build_cmd}")
@@ -87,31 +88,13 @@ class BuildExtension(build_ext):
                 f"cmake {cmake_args} -B {self.build_temp} -S {sherpa_dir}"
             )
             if ret != 0:
-                raise Exception("Failed to build sherpa")
-
-            ret = os.system(
-                f"cmake --build {self.build_temp} --target sherpa --config release -- -m"  # noqa
-            )
-            if ret != 0:
-                raise Exception("failed to build sherpa")
-
-            ret = os.system(
-                f"cmake --build {self.build_temp} --target sherpa-version --config release -- -m"  # noqa
-            )
-            if ret != 0:
-                raise Exception("failed to build sherpa-version")
-
-            ret = os.system(
-                f"cmake --build {self.build_temp} --target _sherpa --config release -- -m"  # noqa
-            )
-            if ret != 0:
-                raise Exception("failed to build _sherpa")
+                raise Exception("Failed to configure sherpa")
 
             ret = os.system(
                 f"cmake --build {self.build_temp} --target install --config Release -- -m"  # noqa
             )
             if ret != 0:
-                raise Exception("Failed to install sherpa")
+                raise Exception("Failed to build and install sherpa")
         else:
             if make_args == "" and system_make_args == "":
                 print("for fast compilation, run:")
@@ -124,8 +107,7 @@ class BuildExtension(build_ext):
 
                 cmake {cmake_args} {sherpa_dir}
 
-
-                make {make_args} sherpa sherpa-version _sherpa install
+                make {make_args} install
             """
             print(f"build command is:\n{build_cmd}")
 
@@ -136,3 +118,8 @@ class BuildExtension(build_ext):
                     "You can ask for help by creating an issue on GitHub.\n"
                     "\nClick:\n\thttps://github.com/k2-fsa/sherpa/issues/new\n"  # noqa
                 )
+
+        for f in ["sherpa", "sherpa-version"]:
+            src_file = install_dir / "bin" / f
+            print(f"Copying {src_file} to {out_bin_dir}/")
+            shutil.copy(f"{src_file}", f"{out_bin_dir}/")

--- a/cmake/kaldi_native_io.cmake
+++ b/cmake/kaldi_native_io.cmake
@@ -1,27 +1,39 @@
-if(DEFINED ENV{KALDI_NATIVE_IO_INSTALL_PREFIX})
-  message(STATUS "Using environment variable KALDI_NATIVE_IO_INSTALL_PREFIX: $ENV{KALDI_NATIVE_IO_INSTALL_PREFIX}")
-  set(KALDI_NATIVE_IO_CMAKE_PREFIX_PATH $ENV{KALDI_NATIVE_IO_INSTALL_PREFIX})
-else()
-  # PYTHON_EXECUTABLE is set by cmake/pybind11.cmake
-  message(STATUS "Python executable: ${PYTHON_EXECUTABLE}")
+function(download_kaldi_native_io)
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    # FetchContent is available since 3.11,
+    # we've copied it to ${CMAKE_SOURCE_DIR}/cmake/Modules
+    # so that it can be used in lower CMake versions.
+    message(STATUS "Use FetchContent provided by sherpa")
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+  endif()
 
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "import kaldi_native_io; print(kaldi_native_io.cmake_prefix_path)"
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE KALDI_NATIVE_IO_CMAKE_PREFIX_PATH
+  include(FetchContent)
+
+  set(kaldi_native_io_URL  "https://github.com/csukuangfj/kaldi_native_io/archive/refs/tags/v1.14.tar.gz")
+  set(kaldi_native_io_HASH "SHA256=c7dc0a2cda061751a121094ad850f8575f3552d223747021aba0b3abd3827622")
+
+  set(KALDI_NATIVE_IO_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  set(KALDI_NATIVE_IO_BUILD_PYTHON OFF CACHE BOOL "" FORCE)
+
+  FetchContent_Declare(kaldi_native_io
+    URL               ${kaldi_native_io_URL}
+    URL_HASH          ${kaldi_native_io_HASH}
   )
-endif()
 
-message(STATUS "KALDI_NATIVE_IO_CMAKE_PREFIX_PATH: ${KALDI_NATIVE_IO_CMAKE_PREFIX_PATH}")
-list(APPEND CMAKE_PREFIX_PATH "${KALDI_NATIVE_IO_CMAKE_PREFIX_PATH}")
+  FetchContent_GetProperties(kaldi_native_io)
+  if(NOT kaldi_native_io_POPULATED)
+    message(STATUS "Downloading kaldi_native_io${kaldi_native_io_URL}")
+    FetchContent_Populate(kaldi_native_io)
+  endif()
+  message(STATUS "kaldi_native_io is downloaded to ${kaldi_native_io_SOURCE_DIR}")
+  message(STATUS "kaldi_native_io's binary dir is ${kaldi_native_io_BINARY_DIR}")
 
-find_package(kaldi_native_io REQUIRED)
+  add_subdirectory(${kaldi_native_io_SOURCE_DIR} ${kaldi_native_io_BINARY_DIR} EXCLUDE_FROM_ALL)
 
-message(STATUS "KALDI_NATIVE_IO_FOUND: ${KALDI_NATIVE_IO_FOUND}")
-message(STATUS "KALDI_NATIVE_IO_VERSION: ${KALDI_NATIVE_IO_VERSION}")
-message(STATUS "KALDI_NATIVE_IO_INCLUDE_DIRS: ${KALDI_NATIVE_IO_INCLUDE_DIRS}")
-message(STATUS "KALDI_NATIVE_IO_CXX_FLAGS: ${KALDI_NATIVE_IO_CXX_FLAGS}")
-message(STATUS "KALDI_NATIVE_IO_LIBRARIES: ${KALDI_NATIVE_IO_LIBRARIES}")
+  target_include_directories(kaldi_native_io_core
+    PUBLIC
+      ${kaldi_native_io_SOURCE_DIR}/
+  )
+endfunction()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KALDI_NATIVE_IO_CXX_FLAGS}")
-message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+download_kaldi_native_io()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import re
 import sys
-from distutils.util import get_platform
 from pathlib import Path
 
 import setuptools
@@ -41,9 +40,7 @@ def get_package_version():
 
 
 def get_binaries_to_install():
-    plat_name = get_platform()  # e.g., linux-x86_64
-    plat_specifier = ".%s-%d.%d" % (plat_name, *sys.version_info[:2])
-    bin_dir = Path("build") / ("lib" + plat_specifier) / "sherpa" / "bin"
+    bin_dir = Path("build") / "sherpa" / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     exe = []
     for f in ["sherpa", "sherpa-version"]:

--- a/sherpa/csrc/CMakeLists.txt
+++ b/sherpa/csrc/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(sherpa_core PUBLIC
   ${TORCH_LIBRARIES}
   ${K2_LIBRARIES}
   ${KALDIFEAT_LIBRARIES}
-  ${KALDI_NATIVE_IO_LIBRARIES}
+  kaldi_native_io_core
   )
 
 target_compile_definitions(sherpa_core PUBLIC SHERPA_TORCH_VERSION_MAJOR=${SHERPA_TORCH_VERSION_MAJOR})
@@ -103,7 +103,8 @@ message(STATUS "Generated ${CMAKE_CURRENT_BINARY_DIR}/version.h")
 add_executable(sherpa-version version.cc)
 target_include_directories(sherpa-version PRIVATE ${CMAKE_BINARY_DIR})
 
-install(TARGETS sherpa_core
+install(TARGETS
+    sherpa_core kaldi_native_io_core
   DESTINATION lib
 )
 

--- a/sherpa/csrc/version.cc
+++ b/sherpa/csrc/version.cc
@@ -42,9 +42,6 @@ int main() {
   os << "kaldifeat version used to build sherpa: " << sherpa::kKaldifeatVersion
      << "\n";
 
-  os << "kaldi_native_io version used to build sherpa: "
-     << sherpa::kKaldiNativeIOVersion << "\n";
-
   os << "cmake version: " << sherpa::kCMakeVersion << "\n";
   os << "compiler ID: " << sherpa::kCompilerID << "\n";
   os << "compiler: " << sherpa::kCompiler << "\n";

--- a/sherpa/csrc/version.h.in
+++ b/sherpa/csrc/version.h.in
@@ -60,9 +60,6 @@ static constexpr const char *kK2WithCuda = "@K2_WITH_CUDA@";
 
 static constexpr const char *kKaldifeatVersion = "@KALDIFEAT_VERSION@";
 
-static constexpr const char *kKaldiNativeIOVersion =
-    "@KALDI_NATIVE_IO_VERSION@";
-
 // e.g., 3.18.0
 static constexpr const char *kCMakeVersion = "@CMAKE_VERSION@";
 


### PR DESCRIPTION
Compile `kaldi_native_io` from source so that it uses the same cxx11 abi as the one used by PyTorch.

Note: Some versions of PyTorch are compiled with `-D_GLIBCXX_USE_CXX11_ABI=0` while some are with `-D_GLIBCXX_USE_CXX11_ABI=1`.  Compiling `kaldi-native-io` from source can avoid  issues caused by different ABI settings.
