### PR TITLE
WIP: Add timestamps for streaming ASR

### DIFF
--- a/sherpa/bin/lstm_transducer_stateless/beam_search.py
+++ b/sherpa/bin/lstm_transducer_stateless/beam_search.py
@@ -132,7 +132,7 @@ class FastBeamSearch:
 
         processed_lens = (num_processed_frames >> 2) + encoder_out_lens
         if self.decoding_method == "fast_beam_search_nbest":
-            next_hyp_list, next_trailing_blank_frames = fast_beam_search_nbest(
+            res = fast_beam_search_nbest(
                 model=model,
                 encoder_out=encoder_out,
                 processed_lens=processed_lens,
@@ -144,10 +144,7 @@ class FastBeamSearch:
                 temperature=self.beam_search_params["temperature"],
             )
         elif self.decoding_method == "fast_beam_search_nbest_LG":
-            (
-                next_hyp_list,
-                next_trailing_blank_frames,
-            ) = fast_beam_search_nbest_LG(
+            res = fast_beam_search_nbest_LG(
                 model=model,
                 encoder_out=encoder_out,
                 processed_lens=processed_lens,
@@ -159,10 +156,7 @@ class FastBeamSearch:
                 temperature=self.beam_search_params["temperature"],
             )
         elif self.decoding_method == "fast_beam_search":
-            (
-                next_hyp_list,
-                next_trailing_blank_frames,
-            ) = fast_beam_search_one_best(
+            res = fast_beam_search_one_best(
                 model=model,
                 encoder_out=encoder_out,
                 processed_lens=processed_lens,
@@ -177,8 +171,12 @@ class FastBeamSearch:
         next_state_list = unstack_states(next_states)
         for i, s in enumerate(stream_list):
             s.states = next_state_list[i]
-            s.hyp = next_hyp_list[i]
-            s.num_trailing_blank_frames = next_trailing_blank_frames[i]
+            s.hyp = res.hyps[i]
+            s.num_trailing_blank_frames = res.num_trailing_blanks[i]
+            s.frame_offset += encoder_out.size(1)
+            s.segment_frame_offset += encoder_out.size(1)
+            s.timestamps = res.timestamps[i]
+            s.tokens = res.tokens[i]
 
     def get_texts(self, stream: Stream) -> str:
         """
@@ -197,6 +195,22 @@ class FastBeamSearch:
             # For Chinese
             result = [self.token_table[i] for i in stream.hyp]
             result = "".join(result)
+
+        return result
+
+    def get_tokens(self, stream: Stream) -> str:
+        """
+        Return tokens after decoding
+        Args:
+          stream:
+            Stream to be processed.
+        """
+        tokens = stream.tokens
+
+        if hasattr(self, "sp"):
+            result = [self.sp.id_to_piece(i) for i in tokens]
+        else:
+            result = [self.token_table[i] for i in tokens]
 
         return result
 

--- a/sherpa/bin/lstm_transducer_stateless/beam_search.py
+++ b/sherpa/bin/lstm_transducer_stateless/beam_search.py
@@ -244,6 +244,10 @@ class GreedySearch:
             self.beam_search_params["blank_id"]
         ] * self.beam_search_params["context_size"]
 
+        # timestamps[i] is the frame number on which stream.hyp[i+context_size]
+        # is decoded
+        stream.timestamps = []  # containing frame numbers after subsampling
+
     @torch.no_grad()
     def process(
         self,
@@ -266,9 +270,13 @@ class GreedySearch:
         chunk_length = server.chunk_length
         batch_size = len(stream_list)
         chunk_length_pad = server.chunk_length_pad
-        state_list, feature_list = [], []
-        decoder_out_list, hyp_list = [], []
+        state_list = []
+        feature_list = []
+        decoder_out_list = []
+        hyp_list = []
         num_trailing_blank_frames_list = []
+        frame_offset_list = []
+        timestamps_list = []
 
         for s in stream_list:
             decoder_out_list.append(s.decoder_out)
@@ -282,6 +290,8 @@ class GreedySearch:
             feature_list.append(b)
 
             num_trailing_blank_frames_list.append(s.num_trailing_blank_frames)
+            frame_offset_list.append(s.segment_frame_offset)
+            timestamps_list.append(s.timestamps)
 
         features = torch.stack(feature_list, dim=0).to(device)
         states = stack_states(state_list)
@@ -311,12 +321,15 @@ class GreedySearch:
             next_decoder_out,
             next_hyp_list,
             next_trailing_blank_frames,
+            next_timestamps,
         ) = streaming_greedy_search(
             model=model,
             encoder_out=encoder_out,
             decoder_out=decoder_out,
             hyps=hyp_list,
             num_trailing_blank_frames=num_trailing_blank_frames_list,
+            frame_offset=frame_offset_list,
+            timestamps=timestamps_list,
         )
 
         next_decoder_out_list = next_decoder_out.split(1)
@@ -327,6 +340,9 @@ class GreedySearch:
             s.decoder_out = next_decoder_out_list[i]
             s.hyp = next_hyp_list[i]
             s.num_trailing_blank_frames = next_trailing_blank_frames[i]
+            s.timestamps = next_timestamps[i]
+            s.frame_offset += encoder_out.size(1)
+            s.segment_frame_offset += encoder_out.size(1)
 
     def get_texts(self, stream: Stream) -> str:
         """
@@ -341,6 +357,21 @@ class GreedySearch:
         else:
             result = [self.token_table[i] for i in hyp]
             result = "".join(result)
+
+        return result
+
+    def get_tokens(self, stream: Stream) -> str:
+        """
+        Return tokens after decoding
+        Args:
+          stream:
+            Stream to be processed.
+        """
+        hyp = stream.hyp[self.beam_search_params["context_size"] :]
+        if hasattr(self, "sp"):
+            result = [self.sp.id_to_piece(i) for i in hyp]
+        else:
+            result = [self.token_table[i] for i in hyp]
 
         return result
 

--- a/sherpa/bin/lstm_transducer_stateless/beam_search.py
+++ b/sherpa/bin/lstm_transducer_stateless/beam_search.py
@@ -414,6 +414,7 @@ class ModifiedBeamSearch:
         state_list = []
         hyps_list = []
         feature_list = []
+        frame_offset_list = []
         for s in stream_list:
             state_list.append(s.states)
             hyps_list.append(s.hyps)
@@ -424,6 +425,7 @@ class ModifiedBeamSearch:
 
             b = torch.cat(f, dim=0)
             feature_list.append(b)
+            frame_offset_list.append(s.segment_frame_offset)
 
         features = torch.stack(feature_list, dim=0).to(device)
         states = stack_states(state_list)
@@ -446,6 +448,7 @@ class ModifiedBeamSearch:
             model=model,
             encoder_out=encoder_out,
             hyps=hyps_list,
+            frame_offset=frame_offset_list,
             num_active_paths=self.beam_search_params["num_active_paths"],
         )
 
@@ -453,8 +456,14 @@ class ModifiedBeamSearch:
         for i, s in enumerate(stream_list):
             s.states = next_state_list[i]
             s.hyps = next_hyps_list[i]
-            trailing_blanks = s.hyps.get_most_probable(True).num_trailing_blanks
+
+            best_hyp = s.hyps.get_most_probable(True)
+
+            trailing_blanks = best_hyp.num_trailing_blanks
+            s.timestamps = best_hyp.timestamps
             s.num_trailing_blank_frames = trailing_blanks
+            s.frame_offset += encoder_out.size(1)
+            s.segment_frame_offset += encoder_out.size(1)
 
     def get_texts(self, stream: Stream) -> str:
         hyp = stream.hyps.get_most_probable(True).ys[
@@ -465,5 +474,22 @@ class ModifiedBeamSearch:
         else:
             result = [self.token_table[i] for i in hyp]
             result = "".join(result)
+
+        return result
+
+    def get_tokens(self, stream: Stream) -> str:
+        """
+        Return tokens after decoding
+        Args:
+          stream:
+            Stream to be processed.
+        """
+        hyp = stream.hyps.get_most_probable(True).ys[
+            self.beam_search_params["context_size"] :
+        ]
+        if hasattr(self, "sp"):
+            result = [self.sp.id_to_piece(i) for i in hyp]
+        else:
+            result = [self.token_table[i] for i in hyp]
 
         return result

--- a/sherpa/bin/lstm_transducer_stateless/stream.py
+++ b/sherpa/bin/lstm_transducer_stateless/stream.py
@@ -132,8 +132,14 @@ class Stream(object):
         self.subsampling_factor = subsampling_factor
         self.log_eps = math.log(1e-10)
 
-        # whenever an endpoint is detected, it is incremented
+        # increment on endpointing
         self.segment = 0
+
+        # Number of frames decoded so far (after subsampling)
+        self.frame_offset = 0  # never reset
+
+        # frame offset within the current segment after subsampling
+        self.segment_frame_offset = 0  # reset on endpointing
 
     def accept_waveform(
         self,
@@ -225,5 +231,6 @@ class Stream(object):
             self.num_trailing_blank_frames = 0
             self.processed_frames = 0
             self.segment += 1
+            self.segment_frame_offset = 0
 
         return detected

--- a/sherpa/bin/lstm_transducer_stateless/streaming_server.py
+++ b/sherpa/bin/lstm_transducer_stateless/streaming_server.py
@@ -299,6 +299,7 @@ class StreamingServer(object):
             raise ValueError(
                 f"Decoding method {decoding_method} is not supported."
             )
+        self.decoding_method = decoding_method
 
         if hasattr(self, "sp"):
             self.beam_search.sp = self.sp
@@ -500,6 +501,7 @@ class StreamingServer(object):
                     self.beam_search.init_stream(stream)
 
                 message = {
+                    "method": self.decoding_method,
                     "segment": segment,
                     "frame_offset": frame_offset,
                     "text": hyp,
@@ -529,6 +531,7 @@ class StreamingServer(object):
         )
 
         message = {
+            "method": self.decoding_method,
             "segment": stream.segment,
             "frame_offset": frame_offset,
             "text": hyp,

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
@@ -78,9 +78,18 @@ async def receive_results(socket: websockets.WebSocketServerProtocol):
         segment = result["segment"]
         is_final = result["final"]
         text = result["text"]
+        tokens = result["tokens"]
+        timestamps = result["timestamps"]
 
         if is_final:
-            ans.append(dict(segment=segment, text=text))
+            ans.append(
+                dict(
+                    segment=segment,
+                    text=text,
+                    tokens=tokens,
+                    timestamps=timestamps,
+                )
+            )
             logging.info(f"Final result of segment {segment}: {text}")
             continue
 
@@ -123,6 +132,13 @@ async def run(server_addr: str, server_port: int, test_wav: str):
         for r in decoding_results:
             s += f"segment: {r['segment']}\n"
             s += f"text: {r['text']}\n"
+
+            token_time = []
+            for token, time in zip(r["tokens"], r["timestamps"]):
+                token_time.append((token, time))
+
+            s += f"timestamps: {r['timestamps']}\n"
+            s += f"(token, time): {token_time}\n"
         logging.info(f"{test_wav}\n{s}")
 
 

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py
@@ -75,6 +75,7 @@ async def receive_results(socket: websockets.WebSocketServerProtocol):
     async for message in socket:
         result = json.loads(message)
 
+        method = result["method"]
         segment = result["segment"]
         is_final = result["final"]
         text = result["text"]
@@ -84,6 +85,7 @@ async def receive_results(socket: websockets.WebSocketServerProtocol):
         if is_final:
             ans.append(
                 dict(
+                    method=method,
                     segment=segment,
                     text=text,
                     tokens=tokens,
@@ -130,6 +132,7 @@ async def run(server_addr: str, server_port: int, test_wav: str):
         decoding_results = await receive_task
         s = ""
         for r in decoding_results:
+            s += f"method: {r['method']}\n"
             s += f"segment: {r['segment']}\n"
             s += f"text: {r['text']}\n"
 

--- a/sherpa/csrc/hypothesis.h
+++ b/sherpa/csrc/hypothesis.h
@@ -32,6 +32,10 @@ struct Hypothesis {
   // The predicted tokens so far. Newly predicated tokens are appended.
   std::vector<int32_t> ys;
 
+  // timestamps[i] contains the frame number after subsampling
+  // on which ys[i] is decoded.
+  std::vector<int32_t> timestamps;
+
   // The total score of ys in log space.
   double log_prob = 0;
 

--- a/sherpa/csrc/rnnt_beam_search.cc
+++ b/sherpa/csrc/rnnt_beam_search.cc
@@ -205,8 +205,10 @@ std::vector<std::vector<int32_t>> GreedySearch(
 torch::Tensor StreamingGreedySearch(
     RnntModel &model,  // NOLINT
     torch::Tensor encoder_out, torch::Tensor decoder_out,
+    const std::vector<int32_t> &frame_offset,
     std::vector<std::vector<int32_t>> *hyps,
-    std::vector<int32_t> *num_trailing_blank_frames) {
+    std::vector<int32_t> *num_trailing_blank_frames,
+    std::vector<std::vector<int32_t>> *timestamps) {
   TORCH_CHECK(encoder_out.dim() == 3, encoder_out.dim(), " vs ", 3);
   TORCH_CHECK(decoder_out.dim() == 2, decoder_out.dim(), " vs ", 2);
 
@@ -246,6 +248,7 @@ torch::Tensor StreamingGreedySearch(
       if (index != blank_id && index != unk_id) {
         emitted = true;
         (*hyps)[n].push_back(index);
+        (*timestamps)[n].push_back(t + frame_offset[n]);
         (*num_trailing_blank_frames)[n] = 0;
       } else {
         (*num_trailing_blank_frames)[n] += 1;

--- a/sherpa/csrc/rnnt_beam_search.cc
+++ b/sherpa/csrc/rnnt_beam_search.cc
@@ -433,6 +433,7 @@ std::vector<std::vector<int32_t>> ModifiedBeamSearch(
 std::vector<Hypotheses> StreamingModifiedBeamSearch(
     RnntModel &model,  // NOLINT
     torch::Tensor encoder_out, std::vector<Hypotheses> in_hyps,
+    const std::vector<int32_t> &frame_offset,
     int32_t num_active_paths /*= 4*/) {
   TORCH_CHECK(encoder_out.dim() == 3, encoder_out.dim(), " vs ", 3);
 
@@ -525,6 +526,7 @@ std::vector<Hypotheses> StreamingModifiedBeamSearch(
         int32_t new_token = topk_token_indexes_acc[j];
         if (new_token != blank_id && new_token != unk_id) {
           new_hyp.ys.push_back(new_token);
+          new_hyp.timestamps.push_back(t + frame_offset[k]);
           new_hyp.num_trailing_blanks = 0;
         } else {
           new_hyp.num_trailing_blanks += 1;

--- a/sherpa/csrc/rnnt_beam_search.h
+++ b/sherpa/csrc/rnnt_beam_search.h
@@ -55,17 +55,29 @@ std::vector<std::vector<int32_t>> GreedySearch(
  *                    device as `model`.
  * @param decoder_out A 2-D tensor of shape (N, C). It should be on the same
  *                    device as `model`.
+ * @param frame_offset Its shape is (N,). The i-th element contains the number
+ *                     of frames after subsampling we have decoded so far for
+ *                     the i-th utterance.
  * @param hyps The decoded tokens. Note: It is modified in-place.
- * @param num_trailing_blank_frames  Number of trailing blank frames. It is
- *                                   updated in-place.
+ * @param num_trailing_blank_frames  Its shape is (N,). The i-th element
+ *                                   contains the number of trailing blank
+ *                                   frames after subsampling for the i-th
+ *                                   utterance. It is updated in-place.
+ * @param timestamps Its shape is (N,). timestamps[i].size() == hyps[i].size()
+ *                   timestamps[i][k] is the frame number after subsampling
+ *                   on which hyps[i][k] is decoded. It is modified in-place.
  *
  * @return Return the decoder output for the next chunk.
  */
 torch::Tensor StreamingGreedySearch(
     RnntModel &model,  // NOLINT
     torch::Tensor encoder_out, torch::Tensor decoder_out,
+    const std::vector<int32_t> &frame_offset,
     std::vector<std::vector<int32_t>> *hyps,
-    std::vector<int32_t> *num_trailing_blank_frames);
+    std::vector<int32_t> *num_trailing_blank_frames,
+    std::vector<std::vector<int32_t>> *timestamps
+
+);
 
 /** RNN-T modified beam search for offline recognition.
  *

--- a/sherpa/csrc/rnnt_beam_search.h
+++ b/sherpa/csrc/rnnt_beam_search.h
@@ -113,6 +113,9 @@ std::vector<std::vector<int32_t>> ModifiedBeamSearch(
  * @param encoder_out A 3-D tensor of shape (N, T, C). It should be on the same
  *                    device as `model`.
  * @param hyps The decoded results from the previous chunk.
+ * @param frame_offset Its shape is (N,). The i-th element contains the number
+ *                     of frames after subsampling we have decoded so far for
+ *                     the i-th utterance.
  * @param num_active_paths  Number of active paths for each utterance.
  *                          Note: Due to merging paths with identical token
  *                          sequences, the actual number of active paths for
@@ -123,7 +126,7 @@ std::vector<std::vector<int32_t>> ModifiedBeamSearch(
 std::vector<Hypotheses> StreamingModifiedBeamSearch(
     RnntModel &model,  // NOLINT
     torch::Tensor encoder_out, std::vector<Hypotheses> hyps,
-    int32_t num_active_paths = 4);
+    const std::vector<int32_t> &frame_offset, int32_t num_active_paths = 4);
 
 }  // namespace sherpa
 

--- a/sherpa/python/csrc/hypothesis.cc
+++ b/sherpa/python/csrc/hypothesis.cc
@@ -40,6 +40,10 @@ void PybindHypothesis(py::module &m) {  // NOLINT
         .def_property_readonly(
             "ys",
             [](const PyClass &self) -> std::vector<int32_t> { return self.ys; })
+        .def_property_readonly("timestamps",
+                               [](const PyClass &self) -> std::vector<int32_t> {
+                                 return self.timestamps;
+                               })
         .def_property_readonly("num_trailing_blanks",
                                [](const PyClass &self) -> int32_t {
                                  return self.num_trailing_blanks;

--- a/sherpa/python/csrc/rnnt_beam_search.cc
+++ b/sherpa/python/csrc/rnnt_beam_search.cc
@@ -127,6 +127,9 @@ Args:
     It should be on the same device as ``model``.
   hyps:
     Decoded results from the previous chunk.
+  frame_offset:
+    Its shape is (N,). The i-th element contains the number of frames after
+    subsampling we have decoded so far for the i-th utterance.
   num_active_paths
     Number of active paths for each utterance. Note: Due to merging paths with
     identical token sequences, the actual number of active path for each
@@ -168,7 +171,7 @@ void PybindRnntBeamSearch(py::module &m) {  // NOLINT
 
   m.def("streaming_modified_beam_search", &StreamingModifiedBeamSearch,
         py::arg("model"), py::arg("encoder_out"), py::arg("hyps"),
-        py::arg("num_active_paths") = 4,
+        py::arg("frame_offset"), py::arg("num_active_paths") = 4,
         py::call_guard<py::gil_scoped_release>(),
         kStreamingModifiedBeamSearchDoc);
 }

--- a/sherpa/python/sherpa/__init__.py
+++ b/sherpa/python/sherpa/__init__.py
@@ -39,5 +39,5 @@ from .timestamp import convert_timestamp
 from .utils import (
     add_beam_search_arguments,
     count_num_trailing_zeros,
-    get_texts_and_num_trailing_blanks,
+    get_fast_beam_search_results,
 )

--- a/sherpa/python/sherpa/__init__.py
+++ b/sherpa/python/sherpa/__init__.py
@@ -35,6 +35,7 @@ from .online_endpoint import (
     add_online_endpoint_arguments,
     endpoint_detected,
 )
+from .timestamp import convert_timestamp
 from .utils import (
     add_beam_search_arguments,
     count_num_trailing_zeros,

--- a/sherpa/python/sherpa/timestamp.py
+++ b/sherpa/python/sherpa/timestamp.py
@@ -1,0 +1,27 @@
+from typing import List
+
+
+def convert_timestamp(
+    frames: List[int],
+    subsampling_factor: int,
+    frame_shift_ms: float = 10,
+) -> List[float]:
+    """Convert frame numbers to time (in seconds) given subsampling factor
+    and frame shift (in milliseconds).
+
+    Args:
+      frames:
+        A list of frame numbers after subsampling.
+      subsampling_factor:
+        The subsampling factor of the model.
+      frame_shift_ms:
+        Frame shift in milliseconds between two contiguous frames.
+    Return:
+      Return the time in seconds corresponding to each given frame.
+    """
+    frame_shift = frame_shift_ms / 1000.0
+    ans = []
+    for f in frames:
+        ans.append(f * subsampling_factor * frame_shift)
+
+    return ans

--- a/sherpa/python/test/CMakeLists.txt
+++ b/sherpa/python/test/CMakeLists.txt
@@ -19,6 +19,7 @@ endfunction()
 set(py_test_files
   test_hypothesis.py
   test_online_endpoint.py
+  test_timestamp.py
   test_utils.py
 )
 

--- a/sherpa/python/test/test_timestamp.py
+++ b/sherpa/python/test/test_timestamp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright      2022  Xiaomi Corp.       (authors: Fangjun Kuang)
+#
+# See LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this single test, use
+#
+#  ctest --verbose -R  test_timestamp_py
+
+import unittest
+
+import sherpa
+
+
+class TestTimeStamp(unittest.TestCase):
+    def test_convert_timestamp(self):
+        subsampling_factor = 4
+        frame_shift_ms = 10
+
+        frames = [0, 1, 2, 3, 5, 8, 10]
+        timestamps = sherpa.convert_timestamp(
+            frames,
+            subsampling_factor=4,
+            frame_shift_ms=10,
+        )
+        for i in range(len(frames)):
+            assert timestamps[i] == (
+                frames[i] * subsampling_factor * frame_shift_ms / 1000
+            ), (frames[i], timestamps[i])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sherpa/python/test/test_utils.py
+++ b/sherpa/python/test/test_utils.py
@@ -35,7 +35,7 @@ class TestUtils(unittest.TestCase):
         assert sherpa.count_num_trailing_zeros([1, 0, 0]) == 2
         assert sherpa.count_num_trailing_zeros([0, 0, 0]) == 3
 
-    def test_get_texts_and_num_trailing_blanks_case1(self):
+    def test_fast_beam_search_results_case1(self):
         s1 = """
           0 1 0 0 0.0
           1 2 1 1 0.2
@@ -63,13 +63,10 @@ class TestUtils(unittest.TestCase):
         fsa3 = k2.Fsa.from_str(s3, acceptor=False)
 
         fsa = k2.Fsa.from_fsas([fsa1, fsa2, fsa3])
-        (
-            aux_labels,
-            num_trailing_blanks,
-        ) = sherpa.get_texts_and_num_trailing_blanks(fsa)
+        res = sherpa.get_fast_beam_search_results(fsa)
 
-        assert aux_labels == [[1, 5], [1], [1]]
-        assert num_trailing_blanks == [0, 2, 1]
+        assert res.hyps == [[1, 5], [1], [1]]
+        assert res.num_trailing_blanks == [0, 2, 1]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use the model from https://github.com/k2-fsa/icefall/pull/558 for testing.

```bash
git lfs install
git clone https://huggingface.co/csukuangfj/icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03
```

## Start the server
```bash
export CUDA_VISIBLE_DEVICES=0

nn_encoder_filename=./icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03/exp/encoder_jit_trace-iter-468000-avg-16.pt
nn_decoder_filename=./icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03/exp/decoder_jit_trace-iter-468000-avg-16.pt
nn_joiner_filename=./icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03/exp/joiner_jit_trace-iter-468000-avg-16.pt

bpe_model_filename=./icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03/data/lang_bpe_500/bpe.model

./sherpa/bin/lstm_transducer_stateless/streaming_server.py \
  --endpoint.rule1.must-contain-nonsilence=false \
  --endpoint.rule1.min-trailing-silence=5.0 \
  --endpoint.rule2.min-trailing-silence=2.0 \
  --endpoint.rule3.min-utterance-length=50.0 \
  --port 6006 \
  --decoding-method greedy_search \
  --max-batch-size 50 \
  --max-wait-ms 5 \
  --nn-pool-size 1 \
  --max-active-connections 10 \
  --nn-encoder-filename $nn_encoder_filename \
  --nn-decoder-filename $nn_decoder_filename \
  --nn-joiner-filename $nn_joiner_filename \
  --bpe-model-filename $bpe_model_filename
```

## Start the client
```bash
wave=./test_wavs/1089-134686-0001.wav
wave=./test_wavs/1221-135766-0002.wav

./sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_client.py  \
  --server-port 6006 \
  $wave
```

### Output from the client:
```
2022-09-19 13:08:23,757 INFO [streaming_client.py:93] Final result of segment 0: YET THESE THOUGHTS AFFECTED HESTER PRYNNE LESS WITH HOPE THAN APPREHENSION
2022-09-19 13:08:23,758 INFO [streaming_client.py:142] ./test_wavs/1221-135766-0002.wav
segment: 0
text: YET THESE THOUGHTS AFFECTED HESTER PRYNNE LESS WITH HOPE THAN APPREHENSION
timestamps: [0.56, 0.76, 1.04, 1.12, 1.36, 1.52, 1.76, 1.84, 1.8800000000000001, 
1.92, 2.0, 2.12, 2.24, 2.36, 2.56, 2.6, 2.72, 2.7600000000000002, 2.96, 3.0, 3.24, 
3.4, 3.44, 3.88, 4.2, 4.28, 4.32, 4.4, 4.48, 4.5600000000000005, 4.6000000000000005]
(token, time): [('_YE', 0.56), ('T', 0.76), ('_THE', 1.04), ('SE', 1.12), ('_THOUGHT', 1.36), ('S', 1.52),
 ('_A', 1.76), ('FF', 1.84), ('E', 1.8800000000000001), ('C', 1.92), ('TED', 2.0), ('_HE', 2.12), ('S', 2.24), 
('TER', 2.36), ('_P', 2.56), ('RY', 2.6), ('N', 2.72), ('NE', 2.7600000000000002), ('_', 2.96), ('LESS', 3.0), 
('_WITH', 3.24), ('_HO', 3.4), ('PE', 3.44), ('_THAN', 3.88), ('_A', 4.2), ('PP', 4.28), ('RE', 4.32), ('HE', 4.4), 
('N', 4.48), ('S', 4.5600000000000005), ('ION', 4.6000000000000005)]
```