### PR TITLE
Use a larger value for utterance length in endpointing for the web demo.

### DIFF
--- a/docs/source/python/streaming_asr/conformer/conformer_rnnt_for_Chinese/server.rst
+++ b/docs/source/python/streaming_asr/conformer/conformer_rnnt_for_Chinese/server.rst
@@ -52,6 +52,7 @@ The following shows you how to start the server with the above pretrained model.
     git clone https://huggingface.co/luomingshuang/icefall_asr_wenetspeech_pruned_transducer_stateless5_streaming
 
     ./sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py \
+      --endpoint.rule3.min-utterance-length=1000.0 \
       --port 6006 \
       --max-batch-size 50 \
       --max-wait-ms 5 \

--- a/docs/source/python/streaming_asr/conformer/conformer_rnnt_for_English/server.rst
+++ b/docs/source/python/streaming_asr/conformer/conformer_rnnt_for_English/server.rst
@@ -52,6 +52,7 @@ The following shows you how to start the server with the above pretrained model.
     git clone https://huggingface.co/pkufool/icefall_librispeech_streaming_pruned_transducer_stateless4_20220625
 
     ./sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py \
+      --endpoint.rule3.min-utterance-length=1000.0 \
       --port 6006 \
       --max-batch-size 50 \
       --max-wait-ms 5 \

--- a/docs/source/python/streaming_asr/conv_emformer/server.rst
+++ b/docs/source/python/streaming_asr/conv_emformer/server.rst
@@ -52,6 +52,7 @@ The following shows you how to start the server with the above pretrained model.
     git clone https://huggingface.co/Zengwei/icefall-asr-librispeech-conv-emformer-transducer-stateless2-2022-07-05
 
     ./sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py \
+      --endpoint.rule3.min-utterance-length=1000.0 \
       --port 6007 \
       --max-batch-size 50 \
       --max-wait-ms 5 \

--- a/docs/source/python/streaming_asr/emformer/server.rst
+++ b/docs/source/python/streaming_asr/emformer/server.rst
@@ -52,6 +52,7 @@ The following shows you how to start the server with the above pretrained model.
     git clone https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-stateless-emformer-rnnt2-2022-06-01
 
     ./sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py \
+      --endpoint.rule3.min-utterance-length=1000.0 \
       --port 6007 \
       --max-batch-size 50 \
       --max-wait-ms 5 \

--- a/docs/source/python/streaming_asr/lstm/server.rst
+++ b/docs/source/python/streaming_asr/lstm/server.rst
@@ -36,6 +36,12 @@ pretrained model: `<https://huggingface.co/Zengwei/icefall-asr-librispeech-lstm-
 
 .. hint::
 
+   You can also try the following pretrained model:
+
+   `<https://huggingface.co/csukuangfj/icefall-asr-librispeech-lstm-transducer-stateless2-2022-09-03>`_
+
+.. hint::
+
    You can find pretrained models in ``RESULTS.md`` for all the recipes in
    `icefall <https://github.com/k2-fsa/icefall>`_.
 
@@ -52,6 +58,7 @@ The following shows you how to start the server with the above pretrained model.
     git clone https://huggingface.co/Zengwei/icefall-asr-librispeech-lstm-transducer-stateless-2022-08-18
 
     ./sherpa/bin/lstm_transducer_stateless/streaming_server.py \
+      --endpoint.rule3.min-utterance-length=1000.0 \
       --port 6007 \
       --max-batch-size 50 \
       --max-wait-ms 5 \


### PR DESCRIPTION
so that rule3 for endpointing won't be activated in the web demo. (Its default value is 20, which may be too short for the web demo).