### PR TITLE
Fix sending empty string to the client

### DIFF
--- a/sherpa/bin/pruned_transducer_statelessX/offline_client.py
+++ b/sherpa/bin/pruned_transducer_statelessX/offline_client.py
@@ -95,6 +95,8 @@ async def run(server_addr: str, server_port: int, test_wavs: List[str]):
                 start = end
 
             decoding_results = await websocket.recv()
+            if decoding_results == "<EMPTY>":
+                decoding_results = ""
             logging.info(f"{test_wav}\n{decoding_results}")
         await websocket.send(b"Done")
 

--- a/sherpa/bin/pruned_transducer_statelessX/offline_server.py
+++ b/sherpa/bin/pruned_transducer_statelessX/offline_server.py
@@ -560,6 +560,9 @@ class OfflineServer:
             if result:
                 await socket.send(result)
             else:
+                # If result is an empty string, send something to the client.
+                # Otherwise, socket.send() is a no-op and the client will
+                # wait for a reply indefinitely.
                 await socket.send("<EMPTY>")
 
 

--- a/sherpa/bin/pruned_transducer_statelessX/offline_server.py
+++ b/sherpa/bin/pruned_transducer_statelessX/offline_server.py
@@ -557,7 +557,10 @@ class OfflineServer:
                 result = self.sp.decode(hyp)
             else:
                 result = [self.token_table[i] for i in hyp]
-            await socket.send(result)
+            if result:
+                await socket.send(result)
+            else:
+                await socket.send("<EMPTY>")
 
 
 @torch.no_grad()


### PR DESCRIPTION
When the recognition result is an empty string,  `websocket.send("")` is a no-op (I guess).
As a result, the client will wait indefinitely.

This PR just sends `"<EMPTY>"` to the client so the client gets something and exits.