### PR TITLE
Catch websocket connection closed exception

### DIFF
--- a/sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py
+++ b/sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py
@@ -425,6 +425,8 @@ class StreamingServer(object):
         """
         try:
             await self.handle_connection_impl(socket)
+        except websockets.exceptions.ConnectionClosedError:
+            logging.info(f"{socket.remote_address} disconnected")
         finally:
             # Decrement so that it can accept new connections
             self.current_active_connections -= 1

--- a/sherpa/bin/lstm_transducer_stateless/streaming_server.py
+++ b/sherpa/bin/lstm_transducer_stateless/streaming_server.py
@@ -469,6 +469,8 @@ class StreamingServer(object):
         """
         try:
             await self.handle_connection_impl(socket)
+        except websockets.exceptions.ConnectionClosedError:
+            logging.info(f"{socket.remote_address} disconnected")
         finally:
             # Decrement so that it can accept new connections
             self.current_active_connections -= 1

--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/streaming_server.py
@@ -450,6 +450,8 @@ class StreamingServer(object):
         """
         try:
             await self.handle_connection_impl(socket)
+        except websockets.exceptions.ConnectionClosedError:
+            logging.info(f"{socket.remote_address} disconnected")
         finally:
             # Decrement so that it can accept new connections
             self.current_active_connections -= 1

--- a/sherpa/bin/pruned_transducer_statelessX/offline_server.py
+++ b/sherpa/bin/pruned_transducer_statelessX/offline_server.py
@@ -559,6 +559,8 @@ class OfflineServer:
         """
         try:
             await self.handle_connection_impl(socket)
+        except websockets.exceptions.ConnectionClosedError:
+            logging.info(f"{socket.remote_address} disconnected")
         finally:
             # Decrement so that it can accept new connections
             self.current_active_connections -= 1

--- a/sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py
+++ b/sherpa/bin/streaming_pruned_transducer_statelessX/streaming_server.py
@@ -494,6 +494,8 @@ class StreamingServer(object):
         """
         try:
             await self.handle_connection_impl(socket)
+        except websockets.exceptions.ConnectionClosedError:
+            logging.info(f"{socket.remote_address} disconnected")
         finally:
             # Decrement so that it can accept new connections
             self.current_active_connections -= 1


### PR DESCRIPTION
To catch the following exception on the server side:
```
2022-10-12 13:53:28,006 ERROR [server.py:234] connection handler failed
Traceback (most recent call last):
  File "/ceph-fj/fangjun/software/py38/lib/python3.8/site-packages/websockets/legacy/server.py", line 232, in handler
    await self.ws_handler(self)
  File "./sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py", line 427, in handle_connection
    await self.handle_connection_impl(socket)
  File "./sherpa/bin/conv_emformer_transducer_stateless2/streaming_server.py", line 527, in handle_connection_impl
    await socket.send(json.dumps(message))
  File "/ceph-fj/fangjun/software/py38/lib/python3.8/site-packages/websockets/legacy/protocol.py", line 620, in send
    await self.ensure_open()
  File "/ceph-fj/fangjun/software/py38/lib/python3.8/site-packages/websockets/legacy/protocol.py", line 921, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: received 1005 (no status code [internal]); then sent 1005 (no status code [internal])
```