### PR TITLE
Add doc for sherpa-onnx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,4 +123,7 @@ rst_epilog = """
 .. _Kaldi: https://github.com/kaldi-asr/kaldi
 .. _ncnn: https://github.com/tencent/ncnn
 .. _sherpa-ncnn: https://github.com/k2-fsa/sherpa-ncnn
+.. _onnx: https://github.com/onnx/onnx
+.. _onnxruntime: https://github.com/microsoft/onnxruntime
+.. _sherpa-onnx: https://github.com/k2-fsa/sherpa-onnx
 """

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,3 +43,9 @@ for both streaming ASR and offline ASR (i.e., non-streaming ASR).
    :caption: ncnn
 
    ./ncnn/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: onnx
+
+   ./onnx/index

--- a/docs/source/onnx/index.rst
+++ b/docs/source/onnx/index.rst
@@ -1,0 +1,159 @@
+sherpa-onnx
+===========
+
+We support using `onnx`_ with `onnxruntime`_ to replace PyTorch for neural
+network computation. The code is put in a separate repository `sherpa-onnx`_.
+
+`sherpa-onnx`_ is self-contained and everything can be compiled from source.
+
+.. hint::
+
+   We use pre-compiled `onnxruntime`_ from
+   `<https://github.com/microsoft/onnxruntime/releases>`_.
+
+Please refer to
+`<https://k2-fsa.github.io/icefall/model-export/export-onnx.html>`_
+for how to export models to `onnx`_ format.
+
+In the following, we describe how to build ``sherpa-onnx`` on Linux, macOS,
+and Windows. Also, we show how to use it for speech recognition with
+pretrained models.
+
+.. caution::
+
+   We only provide non-streaming conformer transducer at present.
+   The work for streaming ASR is still on-going.
+
+Build sherpa-onnx for Linux and macOS
+-------------------------------------
+
+.. code-block:: bash
+
+  git clone https://github.com/k2-fsa/sherpa-onnx
+  cd sherpa-onnx
+  mkdir build
+  cd build
+  cmake -DCMAKE_BUILD_TYPE=Release ..
+  make -j6
+
+It will generate a binary ``sherpa-onnx`` inside ``./build/bin``.
+
+Build sherpa-onnx for Windows
+-----------------------------
+
+.. code-block:: bash
+
+  git clone https://github.com/k2-fsa/sherpa-onnx
+  cd sherpa-onnx
+  mkdir build
+  cd build
+  cmake -DCMAKE_BUILD_TYPE=Release ..
+  cmake --build . --config Release
+
+It will generate a binary ``sherpa-onnx.exe`` inside ``./build/bin/Release``.
+
+Speech recognition with sherpa-onnx
+-----------------------------------
+
+In the following, we describe how to use the precompiled binary ``sherpa-onnx``
+for offline speech recognition with pre-trained models.
+
+We provide two examples: One is for English and the other is for Chinese.
+
+English
+^^^^^^^
+
+First, let us download the pretrained model:
+
+.. code-block::
+
+  cd /path/to/sherpa-onnx
+
+  GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13
+  cd icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13
+  git lfs pull --include "exp/onnx/*.onnx"
+
+  cd ..
+
+.. caution::
+
+   You have to use ``git lfs`` to download the pretrained models.
+
+Second, we can use the following command to decode a wave file:
+
+.. code-block:: bash
+
+  ./build/bin/sherpa-onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/data/lang_bpe_500/tokens.txt \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/exp/onnx/encoder.onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/exp/onnx/decoder.onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/exp/onnx/joiner.onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/exp/onnx/joiner_encoder_proj.onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/exp/onnx/joiner_decoder_proj.onnx \
+    ./icefall-asr-librispeech-pruned-transducer-stateless3-2022-05-13/test_wavs/1089-134686-0001.wav
+
+.. caution::
+
+   It supports only wave format and its sampling rate has be to 16 kHz.
+
+.. hint::
+
+   If you are using Windows, please replace ``./build/bin/sherpa-onnx``
+   with ``./build/bin/Release/sherpa-onnx``
+
+.. note::
+
+   Please refer to
+   `<https://github.com/k2-fsa/icefall/blob/master/egs/librispeech/ASR/RESULTS.md#librispeech-bpe-training-results-pruned-stateless-transducer-3-2022-04-29>`_
+   and
+   `<https://k2-fsa.github.io/icefall/model-export/export-onnx.html>`_
+   if you are interested in how the model is trained and exported.
+
+Chinese
+^^^^^^^
+
+First, let us download the pretrained model:
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/luomingshuang/icefall_asr_wenetspeech_pruned_transducer_stateless2
+  cd icefall_asr_wenetspeech_pruned_transducer_stateless2
+  git lfs pull --include "exp/*.onnx"
+
+  cd ..
+
+.. caution::
+
+   You have to use ``git lfs`` to download the pretrained models.
+
+Second, we can use the following command to decode a wave file:
+
+.. code-block:: bash
+
+  ./build/bin/sherpa-onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/data/lang_char/tokens.txt \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/exp/encoder-epoch-10-avg-2.onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/exp/decoder-epoch-10-avg-2.onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/exp/joiner-epoch-10-avg-2.onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/exp/joiner_encoder_proj-epoch-10-avg-2.onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/exp/joiner_decoder_proj-epoch-10-avg-2.onnx \
+    ./icefall_asr_wenetspeech_pruned_transducer_stateless2/test_wavs/DEV_T0000000000.wav
+
+.. caution::
+
+   It supports only wave format and its sampling rate has be to 16 kHz.
+
+.. hint::
+
+   If you are using Windows, please replace ``./build/bin/sherpa-onnx``
+   with ``./build/bin/Release/sherpa-onnx``
+
+.. note::
+
+   Please refer to
+   `<https://github.com/k2-fsa/icefall/blob/master/egs/wenetspeech/ASR/RESULTS.md#2022-05-19>`_
+   and
+   `<https://k2-fsa.github.io/icefall/model-export/export-onnx.html>`_
+   if you are interested in how the model is trained and exported.

--- a/docs/source/onnx/index.rst
+++ b/docs/source/onnx/index.rst
@@ -1,7 +1,7 @@
 sherpa-onnx
 ===========
 
-We support using `onnx`_ with `onnxruntime`_ to replace PyTorch for neural
+We support using `onnx`_ with `onnxruntime`_ to replace `PyTorch`_ for neural
 network computation. The code is put in a separate repository `sherpa-onnx`_.
 
 `sherpa-onnx`_ is self-contained and everything can be compiled from source.
@@ -21,7 +21,7 @@ pretrained models.
 
 .. caution::
 
-   We only provide non-streaming conformer transducer at present.
+   We only provide non-streaming conformer transducer support at present.
    The work for streaming ASR is still on-going.
 
 Build sherpa-onnx for Linux and macOS
@@ -36,7 +36,7 @@ Build sherpa-onnx for Linux and macOS
   cmake -DCMAKE_BUILD_TYPE=Release ..
   make -j6
 
-It will generate a binary ``sherpa-onnx`` inside ``./build/bin``.
+It will generate a binary ``sherpa-onnx`` inside ``./build/bin/``.
 
 Build sherpa-onnx for Windows
 -----------------------------
@@ -50,7 +50,7 @@ Build sherpa-onnx for Windows
   cmake -DCMAKE_BUILD_TYPE=Release ..
   cmake --build . --config Release
 
-It will generate a binary ``sherpa-onnx.exe`` inside ``./build/bin/Release``.
+It will generate a binary ``sherpa-onnx.exe`` inside ``./build/bin/Release/``.
 
 Speech recognition with sherpa-onnx
 -----------------------------------
@@ -65,7 +65,7 @@ English
 
 First, let us download the pretrained model:
 
-.. code-block::
+.. code-block:: bash
 
   cd /path/to/sherpa-onnx
 


### PR DESCRIPTION
We support using [onnx](https://github.com/onnx/onnx) with [onnxruntime](https://github.com/microsoft/onnxruntime) to replace PyTorch for neural network computation. The code is put in a separate repository [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).

[sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) is self-contained and everything can be compiled from source.