### PR TITLE
Support using Emformer model for online_websocket_server

### DIFF
--- a/sherpa/bin/pruned_stateless_emformer_rnnt2/beam_search.py
+++ b/sherpa/bin/pruned_stateless_emformer_rnnt2/beam_search.py
@@ -86,8 +86,8 @@ class FastBeamSearch:
         model = server.model
         device = model.device
         # Note: chunk_length is in frames before subsampling
-        chunk_length = server.chunk_length
-        segment_length = server.segment_length
+        chunk_length = server.model.chunk_length
+        chunk_length_pad = server.chunk_length_pad
         batch_size = len(stream_list)
 
         state_list, feature_list = [], []
@@ -99,8 +99,8 @@ class FastBeamSearch:
 
             state_list.append(s.states)
             processed_frames_list.append(s.processed_frames)
-            f = s.features[:chunk_length]
-            s.features = s.features[segment_length:]
+            f = s.features[:chunk_length_pad]
+            s.features = s.features[chunk_length:]
             b = torch.cat(f, dim=0)
             feature_list.append(b)
 
@@ -271,9 +271,9 @@ class GreedySearch:
         model = server.model
         device = model.device
         # Note: chunk_length is in frames before subsampling
-        chunk_length = server.chunk_length
+        chunk_length = server.model.chunk_length
+        chunk_length_pad = server.chunk_length_pad
         batch_size = len(stream_list)
-        segment_length = server.segment_length
 
         state_list, feature_list = [], []
         decoder_out_list, hyp_list = [], []
@@ -287,8 +287,8 @@ class GreedySearch:
 
             state_list.append(s.states)
 
-            f = s.features[:chunk_length]
-            s.features = s.features[segment_length:]
+            f = s.features[:chunk_length_pad]
+            s.features = s.features[chunk_length:]
             b = torch.cat(f, dim=0)
             feature_list.append(b)
 
@@ -405,8 +405,8 @@ class ModifiedBeamSearch:
         model = server.model
         device = model.device
 
-        segment_length = server.segment_length
-        chunk_length = server.chunk_length
+        chunk_length = server.model.chunk_length
+        chunk_length_pad = server.chunk_length_pad
 
         batch_size = len(stream_list)
 
@@ -419,8 +419,8 @@ class ModifiedBeamSearch:
             state_list.append(s.states)
             hyps_list.append(s.hyps)
 
-            f = s.features[:chunk_length]
-            s.features = s.features[segment_length:]
+            f = s.features[:chunk_length_pad]
+            s.features = s.features[chunk_length:]
 
             b = torch.cat(f, dim=0)
             feature_list.append(b)

--- a/sherpa/csrc/rnnt_emformer_model.h
+++ b/sherpa/csrc/rnnt_emformer_model.h
@@ -83,13 +83,16 @@ class RnntEmformerModel : public RnntModel {
   torch::Tensor ForwardJoiner(const torch::Tensor &encoder_out,
                               const torch::Tensor &decoder_out) override;
 
+  // Hard code the subsampling_factor to 4 here since the subsampling
+  // method uses ((len - 1) // 2 - 1) // 2)
+  int32_t SubsamplingFactor() const override { return subsampling_factor_; }
   torch::Device Device() const override { return device_; }
   int32_t BlankId() const override { return blank_id_; }
   int32_t UnkId() const override { return unk_id_; }
   int32_t ContextSize() const override { return context_size_; }
   int32_t VocabSize() const override { return vocab_size_; }
-  int32_t SegmentLength() const { return segment_length_; }
-  int32_t RightContextLength() const { return right_context_length_; }
+  int32_t ChunkLength() const override { return chunk_length_; }
+  int32_t PadLength() const override { return pad_length_; }
 
  private:
   torch::jit::Module model_;
@@ -104,8 +107,9 @@ class RnntEmformerModel : public RnntModel {
   int32_t unk_id_;
   int32_t vocab_size_;
   int32_t context_size_;
-  int32_t segment_length_;
-  int32_t right_context_length_;
+  int32_t chunk_length_;
+  int32_t pad_length_;
+  int32_t subsampling_factor_ = 4;
 };
 
 }  // namespace sherpa

--- a/sherpa/python/csrc/rnnt_emformer_model.cc
+++ b/sherpa/python/csrc/rnnt_emformer_model.cc
@@ -70,10 +70,8 @@ void PybindRnntEmformerModel(py::module &m) {  // NOLINT
             return self.StateFromIValue(ivalue);
           },
           py::call_guard<py::gil_scoped_release>())
-      .def_property_readonly("segment_length", &PyClass::SegmentLength)
-      .def_property_readonly("vocab_size", &PyClass::VocabSize)
-      .def_property_readonly("right_context_length",
-                             &PyClass::RightContextLength);
+      .def_property_readonly("chunk_length", &PyClass::ChunkLength)
+      .def_property_readonly("pad_length", &PyClass::PadLength);
 }
 
 }  // namespace sherpa


### PR DESCRIPTION
After merging this PR, all transducer models, streaming + non-streaming, from icefall are supported in sherpa (C++ & Python).