### PR TITLE
[Triton] add fast beam search support

### DIFF
--- a/triton/README.md
+++ b/triton/README.md
@@ -101,7 +101,11 @@ Now start server:
 
 ```bash
 # Inside the docker container
+# If you want to use greedy search decoding
 bash /workspace/scripts/start_streaming(offline)_server(_jit).sh
+
+# Or if you want to use fast beam search decoding
+bash /workspace/scripts/start_streaming(offline)_server_fast_beam.sh
 ```
 
 If you meet any issues during the process, please file an issue.

--- a/triton/model_repo_offline_fast_beam/conformer_transducer
+++ b/triton/model_repo_offline_fast_beam/conformer_transducer
@@ -1,0 +1,1 @@
+../model_repo_offline/conformer_transducer

--- a/triton/model_repo_offline_fast_beam/decoder
+++ b/triton/model_repo_offline_fast_beam/decoder
@@ -1,0 +1,1 @@
+../model_repo_offline/decoder

--- a/triton/model_repo_offline_fast_beam/encoder
+++ b/triton/model_repo_offline_fast_beam/encoder
@@ -1,0 +1,1 @@
+../model_repo_offline/encoder

--- a/triton/model_repo_offline_fast_beam/fast_beam_search/1/model.py
+++ b/triton/model_repo_offline_fast_beam/fast_beam_search/1/model.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import triton_python_backend_utils as pb_utils
+import numpy as np
+import k2
+import json
+from typing import Union, List
+import torch
+import sentencepiece as spm
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        self.model_config = model_config = json.loads(args['model_config'])
+        self.max_batch_size = max(model_config["max_batch_size"], 1)
+
+        if "GPU" in model_config["instance_group"][0]["kind"]:
+            self.device = "cuda"
+        else:
+            self.device = "cpu"
+
+        # Get OUTPUT0 configuration
+        output0_config = pb_utils.get_output_config_by_name(
+            model_config, "OUTPUT0")
+        # Convert Triton types to numpy types
+        self.out0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config['data_type'])
+        # Get INPUT configuration
+
+        encoder_config = pb_utils.get_input_config_by_name(
+            model_config, "encoder_out")
+        self.data_type = pb_utils.triton_string_to_numpy(
+            encoder_config['data_type'])
+
+        self.encoder_dim = encoder_config['dims'][-1]
+        self.init_sentence_piece(self.model_config['parameters'])
+
+        # parameters for fast beam search
+        self.beam = int(self.model_config['parameters']['beam'])
+        self.max_contexts = int(self.model_config['parameters']['max_contexts'])
+        self.max_states = int(self.model_config['parameters']['max_states'])
+        self.temperature = float(self.model_config['parameters']['temperature'])
+        # Support fast beam search one best currently
+        self.decoding_graph = k2.trivial_graph(
+                self.vocab_size - 1, device=self.device
+            )       
+
+    def init_sentence_piece(self, parameters):
+        for key,value in parameters.items():
+            parameters[key] = value["string_value"]
+        self.context_size = int(parameters['context_size'])
+        sp = spm.SentencePieceProcessor()
+        sp.load(parameters['bpe_model'])
+        self.blank_id = sp.piece_to_id("<blk>")
+        self.unk_id = sp.piece_to_id("<unk>")
+        self.vocab_size = sp.get_piece_size()
+        self.sp = sp
+
+    def forward_joiner(self, cur_encoder_out, decoder_out):
+        in_joiner_tensor_0 = pb_utils.Tensor("encoder_out", cur_encoder_out.cpu().numpy())
+        in_joiner_tensor_1 = pb_utils.Tensor("decoder_out", decoder_out.cpu().numpy())
+
+        inference_request = pb_utils.InferenceRequest(
+            model_name='joiner',
+            requested_output_names=['logit'],
+            inputs=[in_joiner_tensor_0, in_joiner_tensor_1])
+        inference_response = inference_request.exec()
+        if inference_response.has_error():
+            raise pb_utils.TritonModelException(inference_response.error().message())
+        else:
+            # Extract the output tensors from the inference response.
+            logits = pb_utils.get_output_tensor_by_name(inference_response,
+                                                            'logit')
+            logits = torch.utils.dlpack.from_dlpack(logits.to_dlpack()).cpu()
+            assert len(logits.shape) == 2, logits.shape
+            return logits
+
+
+    def forward_decoder(self, hyps):
+        decoder_input = np.asarray(hyps,dtype=np.int64)
+
+        in_decoder_input_tensor = pb_utils.Tensor("y", decoder_input)
+
+        inference_request = pb_utils.InferenceRequest(
+            model_name='decoder',
+            requested_output_names=['decoder_out'],
+            inputs=[in_decoder_input_tensor])
+
+        inference_response = inference_request.exec()
+        if inference_response.has_error():
+            raise pb_utils.TritonModelException(inference_response.error().message())
+        else:
+            # Extract the output tensors from the inference response.
+            decoder_out = pb_utils.get_output_tensor_by_name(inference_response,
+                                                            'decoder_out')
+            decoder_out = torch.utils.dlpack.from_dlpack(decoder_out.to_dlpack()).cpu()
+            assert len(decoder_out.shape)==3, decoder_out.shape
+            decoder_out = decoder_out.squeeze(1)
+            return decoder_out
+
+    # From k2 utils.py
+    def get_texts(self, 
+        best_paths: k2.Fsa, return_ragged: bool = False
+    ) -> Union[List[List[int]], k2.RaggedTensor]:
+        """Extract the texts (as word IDs) from the best-path FSAs.
+        Args:
+          best_paths:
+            A k2.Fsa with best_paths.arcs.num_axes() == 3, i.e.
+            containing multiple FSAs, which is expected to be the result
+            of k2.shortest_path (otherwise the returned values won't
+            be meaningful).
+          return_ragged:
+            True to return a ragged tensor with two axes [utt][word_id].
+            False to return a list-of-list word IDs.
+        Returns:
+          Returns a list of lists of int, containing the label sequences we
+          decoded.
+        """
+        if isinstance(best_paths.aux_labels, k2.RaggedTensor):
+            # remove 0's and -1's.
+            aux_labels = best_paths.aux_labels.remove_values_leq(0)
+            # TODO: change arcs.shape() to arcs.shape
+            aux_shape = best_paths.arcs.shape().compose(aux_labels.shape)
+
+            # remove the states and arcs axes.
+            aux_shape = aux_shape.remove_axis(1)
+            aux_shape = aux_shape.remove_axis(1)
+            aux_labels = k2.RaggedTensor(aux_shape, aux_labels.values)
+        else:
+            # remove axis corresponding to states.
+            aux_shape = best_paths.arcs.shape().remove_axis(1)
+            aux_labels = k2.RaggedTensor(aux_shape, best_paths.aux_labels)
+            # remove 0's and -1's.
+            aux_labels = aux_labels.remove_values_leq(0)
+
+        assert aux_labels.num_axes == 2
+        if return_ragged:
+            return aux_labels
+        else:
+            return aux_labels.tolist()
+
+    def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference is requested
+        for this model.
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+        # Every Python backend must iterate through list of requests and create
+        # an instance of pb_utils.InferenceResponse class for each of them. You
+        # should avoid storing any of the input Tensors in the class attributes
+        # as they will be overridden in subsequent inference requests. You can
+        # make a copy of the underlying NumPy array and store it if it is
+        # required.
+
+        batch_encoder_out_list, batch_encoder_lens_list = [], []    
+        batchsize_lists = []
+        encoder_max_len = 0
+        batch_idx = 0
+        for request in requests:
+            # Perform inference on the request and append it to responses list...
+            in_0 = pb_utils.get_input_tensor_by_name(request, "encoder_out")
+            in_1 = pb_utils.get_input_tensor_by_name(request, "encoder_out_lens")
+            batch_encoder_out_list.append(in_0.as_numpy())
+            encoder_max_len = max(encoder_max_len, batch_encoder_out_list[-1].shape[1])
+            cur_b_lens = in_1.as_numpy()
+            batch_encoder_lens_list.append(cur_b_lens)
+            cur_batchsize = cur_b_lens.shape[0]
+            batchsize_lists.append(cur_batchsize)
+            batch_idx += 1
+
+        encoder_out_array = np.zeros((batch_idx, encoder_max_len, self.encoder_dim),
+                                  dtype=self.data_type)
+        encoder_out_lens_array = np.zeros(batch_idx, dtype=np.int32)
+
+
+        for i, t in enumerate(batch_encoder_out_list):
+
+            encoder_out_array[i, 0:t.shape[1]] = t
+            encoder_out_lens_array[i] = batch_encoder_lens_list[i]
+
+        encoder_out = torch.from_numpy(encoder_out_array)
+        encoder_out_lens = torch.from_numpy(encoder_out_lens_array)
+
+        B, T, C = encoder_out.shape
+
+        config = k2.RnntDecodingConfig(
+            vocab_size=self.vocab_size,
+            decoder_history_len=self.context_size,
+            beam=self.beam,
+            max_contexts=self.max_contexts,
+            max_states=self.max_states,
+        )
+        individual_streams = []
+        for i in range(B):
+            individual_streams.append(k2.RnntDecodingStream(self.decoding_graph))
+        decoding_streams = k2.RnntDecodingStreams(individual_streams, config)
+
+        for t in range(T):
+            shape, contexts = decoding_streams.get_contexts()
+            contexts = contexts.to(torch.int64)
+
+            decoder_out = self.forward_decoder(contexts)
+
+            cur_encoder_out = torch.index_select(
+                encoder_out[:, t:t + 1, :], 0, shape.row_ids(1).to(torch.int64)
+            )
+
+            logits = self.forward_joiner(cur_encoder_out.squeeze(1),
+                decoder_out)
+
+            logits = logits.squeeze(1).squeeze(1).float()
+            log_probs = (logits / self.temperature).log_softmax(dim=-1)
+            decoding_streams.advance(log_probs)
+        decoding_streams.terminate_and_flush_to_streams()
+        lattice = decoding_streams.format_output(encoder_out_lens.tolist())
+
+        best_path = k2.shortest_path(lattice, use_double_scores=True)
+        hyps_list = self.get_texts(best_path)
+
+        results = []
+        for hyp in self.sp.decode(hyps_list):
+            results.append(hyp.split())
+    
+        st = 0
+        responses = []
+        for b in batchsize_lists:
+            sents = np.array(results[st:st + b])
+            out0 = pb_utils.Tensor("OUTPUT0", sents.astype(self.out0_dtype))
+            inference_response = pb_utils.InferenceResponse(output_tensors=[out0])
+            responses.append(inference_response)
+            st += b
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/triton/model_repo_offline_fast_beam/fast_beam_search/config.pbtxt
+++ b/triton/model_repo_offline_fast_beam/fast_beam_search/config.pbtxt
@@ -1,0 +1,77 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "fast_beam_search"
+backend: "python"
+max_batch_size: 512
+
+parameters [
+  {
+    key: "context_size",
+    value: { string_value: "2"}
+  },
+  {
+    key: "bpe_model",
+    value: { string_value: "/workspace/icefall/models/data/lang_bpe_500/bpe.model"}
+  },
+  {
+    key: "beam",
+    value: { string_value: "4"}
+  },
+  {
+    key: "max_contexts",
+    value: { string_value: "4"}
+  },
+  {
+    key: "max_states",
+    value: { string_value: "32"}
+  },
+  {
+    key: "temperature",
+    value: { string_value: "1.0"}
+  },
+  {
+   key: "FORCE_CPU_ONLY_INPUT_TENSORS", 
+   value: {string_value:"yes"}
+  }
+]
+
+input [
+  {
+    name: "encoder_out"
+    data_type: TYPE_FP16
+    dims: [-1, 512] # [-1, encoder_out_dim]
+  },
+  {
+    name: "encoder_out_lens"
+    data_type: TYPE_INT64
+    dims: [1]
+    reshape: { shape: [ ] }
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_STRING
+    dims: [1]
+  }
+]
+dynamic_batching {
+  }
+instance_group [
+    {
+      count: 2
+      kind: KIND_CPU
+    }
+  ]

--- a/triton/model_repo_offline_fast_beam/feature_extractor
+++ b/triton/model_repo_offline_fast_beam/feature_extractor
@@ -1,0 +1,1 @@
+../model_repo_offline/feature_extractor

--- a/triton/model_repo_offline_fast_beam/joiner
+++ b/triton/model_repo_offline_fast_beam/joiner
@@ -1,0 +1,1 @@
+../model_repo_offline/joiner

--- a/triton/model_repo_streaming_fast_beam/conformer_transducer
+++ b/triton/model_repo_streaming_fast_beam/conformer_transducer
@@ -1,0 +1,1 @@
+../model_repo_streaming/conformer_transducer

--- a/triton/model_repo_streaming_fast_beam/decoder
+++ b/triton/model_repo_streaming_fast_beam/decoder
@@ -1,0 +1,1 @@
+../model_repo_streaming/decoder

--- a/triton/model_repo_streaming_fast_beam/encoder
+++ b/triton/model_repo_streaming_fast_beam/encoder
@@ -1,0 +1,1 @@
+../model_repo_streaming/encoder

--- a/triton/model_repo_streaming_fast_beam/fast_beam_search/1/model.py
+++ b/triton/model_repo_streaming_fast_beam/fast_beam_search/1/model.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import triton_python_backend_utils as pb_utils
+import numpy as np
+import json
+import torch
+import sentencepiece as spm
+import k2
+from typing import Union, List
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+        self.model_config = model_config = json.loads(args['model_config'])
+        self.max_batch_size = max(model_config["max_batch_size"], 1)
+
+        if "GPU" in model_config["instance_group"][0]["kind"]:
+            self.device = "cuda"
+        else:
+            self.device = "cpu"
+
+        # Get OUTPUT0 configuration
+        output0_config = pb_utils.get_output_config_by_name(
+            model_config, "OUTPUT0")
+        # Convert Triton types to numpy types
+        self.out0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config['data_type'])
+
+        # Get INPUT configuration
+
+        encoder_config = pb_utils.get_input_config_by_name(
+            model_config, "encoder_out")
+        self.data_type = pb_utils.triton_string_to_numpy(
+            encoder_config['data_type'])
+
+        self.encoder_dim = encoder_config['dims'][-1]
+        self.init_sentence_piece(self.model_config['parameters'])
+        
+        # parameters for fast beam search
+        self.beam = int(self.model_config['parameters']['beam'])
+        self.max_contexts = int(self.model_config['parameters']['max_contexts'])
+        self.max_states = int(self.model_config['parameters']['max_states'])
+        self.temperature = float(self.model_config['parameters']['temperature'])
+        # Support fast beam search one best currently
+        self.decoding_graph = k2.trivial_graph(
+                self.vocab_size - 1, device=self.device
+            )
+
+        # use to record every sequence state
+        self.seq_states = {}
+        print("Finish Init")
+
+    def init_sentence_piece(self, parameters):
+        for key,value in parameters.items():
+            parameters[key] = value["string_value"]
+        self.context_size = int(parameters['context_size'])
+        sp = spm.SentencePieceProcessor()
+        sp.load(parameters['bpe_model'])
+        self.blank_id = sp.piece_to_id("<blk>")
+        self.unk_id = sp.piece_to_id("<unk>")
+        self.vocab_size = sp.get_piece_size()
+        self.sp = sp
+
+    # From k2 utils.py
+    def get_texts(self, 
+        best_paths: k2.Fsa, return_ragged: bool = False
+    ) -> Union[List[List[int]], k2.RaggedTensor]:
+        """Extract the texts (as word IDs) from the best-path FSAs.
+        Args:
+          best_paths:
+            A k2.Fsa with best_paths.arcs.num_axes() == 3, i.e.
+            containing multiple FSAs, which is expected to be the result
+            of k2.shortest_path (otherwise the returned values won't
+            be meaningful).
+          return_ragged:
+            True to return a ragged tensor with two axes [utt][word_id].
+            False to return a list-of-list word IDs.
+        Returns:
+          Returns a list of lists of int, containing the label sequences we
+          decoded.
+        """
+        if isinstance(best_paths.aux_labels, k2.RaggedTensor):
+            # remove 0's and -1's.
+            aux_labels = best_paths.aux_labels.remove_values_leq(0)
+            # TODO: change arcs.shape() to arcs.shape
+            aux_shape = best_paths.arcs.shape().compose(aux_labels.shape)
+
+            # remove the states and arcs axes.
+            aux_shape = aux_shape.remove_axis(1)
+            aux_shape = aux_shape.remove_axis(1)
+            aux_labels = k2.RaggedTensor(aux_shape, aux_labels.values)
+        else:
+            # remove axis corresponding to states.
+            aux_shape = best_paths.arcs.shape().remove_axis(1)
+            aux_labels = k2.RaggedTensor(aux_shape, best_paths.aux_labels)
+            # remove 0's and -1's.
+            aux_labels = aux_labels.remove_values_leq(0)
+
+        assert aux_labels.num_axes == 2
+        if return_ragged:
+            return aux_labels
+        else:
+            return aux_labels.tolist()
+
+
+    def forward_joiner(self, cur_encoder_out, decoder_out):
+        in_joiner_tensor_0 = pb_utils.Tensor("encoder_out", cur_encoder_out.cpu().numpy())
+        in_joiner_tensor_1 = pb_utils.Tensor("decoder_out", decoder_out.cpu().numpy())
+
+        inference_request = pb_utils.InferenceRequest(
+            model_name='joiner',
+            requested_output_names=['logit'],
+            inputs=[in_joiner_tensor_0, in_joiner_tensor_1])
+        inference_response = inference_request.exec()
+        if inference_response.has_error():
+            raise pb_utils.TritonModelException(inference_response.error().message())
+        else:
+            # Extract the output tensors from the inference response.
+            logits = pb_utils.get_output_tensor_by_name(inference_response,
+                                                            'logit')
+            logits = torch.utils.dlpack.from_dlpack(logits.to_dlpack()).cpu()
+            assert len(logits.shape) == 2, logits.shape
+            return logits
+
+
+    def forward_decoder(self,hyps):
+        decoder_input = np.asarray(hyps, dtype=np.int64)
+
+        in_decoder_input_tensor = pb_utils.Tensor("y", decoder_input)
+
+        inference_request = pb_utils.InferenceRequest(
+            model_name='decoder',
+            requested_output_names=['decoder_out'],
+            inputs=[in_decoder_input_tensor])
+
+        inference_response = inference_request.exec()
+        if inference_response.has_error():
+            raise pb_utils.TritonModelException(inference_response.error().message())
+        else:
+            # Extract the output tensors from the inference response.
+            decoder_out = pb_utils.get_output_tensor_by_name(inference_response,
+                                                            'decoder_out')
+            decoder_out = torch.utils.dlpack.from_dlpack(decoder_out.to_dlpack()).cpu()
+            assert len(decoder_out.shape)==3, decoder_out.shape
+            decoder_out = decoder_out.squeeze(1)
+            return decoder_out
+            
+
+    def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference is requested
+        for this model.
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+        # Every Python backend must iterate through list of requests and create
+        # an instance of pb_utils.InferenceResponse class for each of them. You
+        # should avoid storing any of the input Tensors in the class attributes
+        # as they will be overridden in subsequent inference requests. You can
+        # make a copy of the underlying NumPy array and store it if it is
+        # required.
+
+        batch_encoder_out_list, batch_encoder_lens_list = [], []    
+        batch_idx = 0
+        encoder_max_len = 0
+
+
+        batch_idx2_corrid = {}
+    
+        hyps_list = []
+        decoder_out_list = []
+        end_idx = set()
+
+        for request in requests:
+            # Perform inference on the request and append it to responses list...
+            in_0 = pb_utils.get_input_tensor_by_name(request, "encoder_out")
+            in_1 = pb_utils.get_input_tensor_by_name(request, "encoder_out_lens")
+
+            # TODO: directly use torch tensor from_dlpack(in_0.to_dlpack())
+            batch_encoder_out_list.append(in_0.as_numpy())
+
+            assert batch_encoder_out_list[-1].shape[0] == 1            
+            encoder_max_len = max(encoder_max_len, batch_encoder_out_list[-1].shape[1])
+
+            cur_b_lens = in_1.as_numpy()
+            batch_encoder_lens_list.append(cur_b_lens)
+
+            assert encoder_max_len == cur_b_lens[0]
+
+            # For streaming ASR, assert each request sent from client has batch size 1.
+            
+
+            in_start = pb_utils.get_input_tensor_by_name(request, "START")
+            start = in_start.as_numpy()[0][0]
+
+            in_ready = pb_utils.get_input_tensor_by_name(request, "READY")
+            ready = in_ready.as_numpy()[0][0]
+
+            in_corrid = pb_utils.get_input_tensor_by_name(request, "CORRID")
+            corrid = in_corrid.as_numpy()[0][0]
+
+            in_end = pb_utils.get_input_tensor_by_name(request, "END")
+            end = in_end.as_numpy()[0][0]
+
+            if start and ready:
+                # intialize states
+                #init_hyp = [self.blank_id] * self.context_size
+                #init_decoder_out = self.forward_decoder([init_hyp])   
+                init_hyp = None
+                init_decoder_out = None
+                self.seq_states[corrid] = [init_hyp, init_decoder_out]
+
+            if end and ready:
+                end_idx.add(batch_idx)
+    
+            if ready:
+                hyp, decoder_out = self.seq_states[corrid]
+                batch_idx2_corrid[batch_idx] = corrid
+                hyps_list.append(hyp)
+                decoder_out_list.append(decoder_out)
+
+            batch_idx += 1
+
+        encoder_out_array = np.zeros((batch_idx, encoder_max_len, self.encoder_dim),
+                                  dtype=self.data_type)
+        encoder_out_lens_array = np.zeros(batch_idx, dtype=np.int32)
+
+
+        for i, t in enumerate(batch_encoder_out_list):
+            
+            encoder_out_array[i, 0:t.shape[1]] = t
+            encoder_out_lens_array[i] = batch_encoder_lens_list[i]
+    
+        encoder_out = torch.from_numpy(encoder_out_array)
+        encoder_out_lens = torch.from_numpy(encoder_out_lens_array)
+
+
+
+        B, T, C = encoder_out.shape
+
+        config = k2.RnntDecodingConfig(
+            vocab_size=self.vocab_size,
+            decoder_history_len=self.context_size,
+            beam=self.beam,
+            max_contexts=self.max_contexts,
+            max_states=self.max_states,
+        )
+        individual_streams = []
+        for i in range(B):
+            individual_streams.append(k2.RnntDecodingStream(self.decoding_graph))
+        decoding_streams = k2.RnntDecodingStreams(individual_streams, config)
+
+        for t in range(T):
+            shape, contexts = decoding_streams.get_contexts()
+            contexts = contexts.to(torch.int64)
+
+            # decoder_out = model.decoder(contexts, need_pad=False)
+            # decoder_out = model.joiner.decoder_proj(decoder_out)
+
+            decoder_out = self.forward_decoder(contexts)
+
+            cur_encoder_out = torch.index_select(
+                encoder_out[:, t:t + 1, :], 0, shape.row_ids(1).to(torch.int64)
+            )
+
+            #print(cur_encoder_out.shape)
+            #print(decoder_out.shape)
+            logits = self.forward_joiner(cur_encoder_out.unsqueeze(1),
+                decoder_out)
+
+            logits = logits.squeeze(1).squeeze(1)
+            log_probs = (logits / self.temperature).log_softmax(dim=-1)
+            decoding_streams.advance(log_probs)
+        decoding_streams.terminate_and_flush_to_streams()
+        lattice = decoding_streams.format_output(encoder_out_lens.tolist())
+
+        best_path = k2.shortest_path(lattice, use_double_scores=True)
+        hyps_list = self.get_texts(best_path)
+
+        responses = []
+        for i in range(B):
+            #hyp = hyps_list[i][self.context_size:]
+            hyp = hyps_list[i]
+            #sent = self.sp.decode(hyp).split()
+            sent = self.sp.decode(hyp).split()
+            sent = np.array(sent)
+            out_tensor_0 = pb_utils.Tensor("OUTPUT0", sent.astype(self.out0_dtype))
+            inference_response = pb_utils.InferenceResponse(output_tensors=[out_tensor_0])
+            responses.append(inference_response)
+    
+            corr = batch_idx2_corrid[i]
+            if i in end_idx:
+                del self.seq_states[corr]
+            else:
+                self.seq_states[corr] = [hyps_list[i], decoder_out[i].unsqueeze(0)]
+                    
+        assert len(requests) == len(responses)
+        return responses
+    
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is optional. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/triton/model_repo_streaming_fast_beam/fast_beam_search/config.pbtxt
+++ b/triton/model_repo_streaming_fast_beam/fast_beam_search/config.pbtxt
@@ -1,0 +1,124 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "fast_beam_search"
+backend: "python"
+max_batch_size: 512
+
+sequence_batching{
+    max_sequence_idle_microseconds: 5000000
+    oldest {
+      max_candidate_sequences: 1024
+    }
+    control_input [
+        {
+            name: "START",
+            control [
+                {
+                    kind: CONTROL_SEQUENCE_START
+                    fp32_false_true: [0, 1]
+                }
+            ]
+        },
+        {
+            name: "READY"
+            control [
+                {
+                    kind: CONTROL_SEQUENCE_READY
+                    fp32_false_true: [0, 1]
+                }
+            ]
+        },
+        {
+            name: "CORRID",
+            control [
+                {
+                    kind: CONTROL_SEQUENCE_CORRID
+                    data_type: TYPE_UINT64
+                }
+            ]
+        },
+        {
+            name: "END",
+            control [
+                {
+                    kind: CONTROL_SEQUENCE_END
+                    fp32_false_true: [0, 1]
+                }
+            ]
+        }
+    ]
+}
+
+
+parameters [
+  {
+    key: "context_size",
+    value: { string_value: "2"}
+  },
+  {
+    key: "bpe_model",
+    value: { string_value: "/workspace/icefall/egs/librispeech/ASR/icefall_librispeech_streaming_pruned_transducer_stateless3_giga_0.9_20220625/data/lang_bpe_500/bpe.model"}
+  },
+  {
+    key: "beam",
+    value: { string_value: "4"}
+  },
+  {
+    key: "max_contexts",
+    value: { string_value: "4"}
+  },
+  {
+    key: "max_states",
+    value: { string_value: "32"}
+  },
+  {
+    key: "temperature",
+    value: { string_value: "1.0"}
+  },
+  {
+   key: "FORCE_CPU_ONLY_INPUT_TENSORS", 
+   value: {string_value:"yes"}
+  }
+]
+
+
+input [
+  {
+    name: "encoder_out"
+    data_type: TYPE_FP32
+    dims: [-1, 512] # [-1, encoder_out_dim]
+  },
+  {
+    name: "encoder_out_lens"
+    data_type: TYPE_INT64
+    dims: [1]
+    reshape: { shape: [ ] }
+  }
+]
+
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_STRING
+    dims: [1]
+  }
+]
+
+instance_group [
+    {
+      count: 2
+      kind: KIND_CPU
+    }
+  ]

--- a/triton/model_repo_streaming_fast_beam/feature_extractor
+++ b/triton/model_repo_streaming_fast_beam/feature_extractor
@@ -1,0 +1,1 @@
+../model_repo_streaming/feature_extractor

--- a/triton/model_repo_streaming_fast_beam/joiner
+++ b/triton/model_repo_streaming_fast_beam/joiner
@@ -1,0 +1,1 @@
+../model_repo_streaming/joiner

--- a/triton/scripts/start_offline_server_fast_beam.sh
+++ b/triton/scripts/start_offline_server_fast_beam.sh
@@ -1,0 +1,23 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+onnx_dir=/workspace/icefall/egs/librispeech/ASR/icefall-asr-librispeech-pruned-transducer-stateless3-2022-04-29/exp
+model_repo_dir=/workspace/sherpa/triton/model_repo_offline_fast_beam
+cp $onnx_dir/encoder_fp16.onnx $model_repo_dir/encoder/1/encoder.onnx
+cp $onnx_dir/decoder_fp16.onnx $model_repo_dir/decoder/1/decoder.onnx
+cp $onnx_dir/joiner_fp16.onnx $model_repo_dir/joiner/1/joiner.onnx
+cp $onnx_dir/../data/lang_bpe_500/bpe.model /workspace/
+# Start server
+tritonserver --model-repository=$model_repo_dir --pinned-memory-pool-byte-size=512000000 --cuda-memory-pool-byte-size=0:1024000000
+

--- a/triton/scripts/start_streaming_server_fast_beam.sh
+++ b/triton/scripts/start_streaming_server_fast_beam.sh
@@ -1,0 +1,22 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+onnx_dir=/workspace/icefall/egs/librispeech/ASR/icefall_librispeech_streaming_pruned_transducer_stateless3_giga_0.9_20220625/exp
+model_repo_dir=/workspace/sherpa/triton/model_repo_streaming_fast_beam
+cp $onnx_dir/encoder_fp16.onnx $model_repo_dir/encoder/1/encoder.onnx
+cp $onnx_dir/decoder_fp16.onnx $model_repo_dir/decoder/1/decoder.onnx
+cp $onnx_dir/joiner_fp16.onnx $model_repo_dir/joiner/1/joiner.onnx
+
+# Start server
+tritonserver --model-repository=$model_repo_dir --pinned-memory-pool-byte-size=512000000 --cuda-memory-pool-byte-size=0:1024000000


### PR DESCRIPTION
This PR adds fast beam search decoding for offline and streaming ASR triton server.
Currently, triton support table 
|  Mode	     | Protobuf	|  Precision|  Decoding Method	    |     Model  	|  Support |
|------------|----------|-----------|-----------------------|---------------|----------|
| Streaming	 |  Onnx	|    FP32	|   Greedy Search	    |  Conformer-T	|   Yes    |
|            |          |           |  Fast Beam Search     |  Conformer-T	|   Yes    |
| Offline	 |  Onnx	|    FP32	|   Greedy Search	    |  Conformer-T	|   Yes    |
| Streaming	 |  Onnx	|    FP16	|   Greedy Search	    |  Conformer-T	|   Yes    |
| Offline	 |  Onnx	|    FP16	|   Greedy Search	    |  Conformer-T	|   Yes    |
|            |          |           |  Fast Beam Search     |  Conformer-T	|   Yes    |
| Offline	 |  Jit	    |    FP32	|   Greedy search	    |  Conformer-T	|   Yes    |

Thanks!! 
