### PR TITLE
Fix building for colab

### DIFF
--- a/sherpa/cpp_api/bin/CMakeLists.txt
+++ b/sherpa/cpp_api/bin/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT WIN32)
   if(NOT DEFINED ENV{VIRTUAL_ENV})
     message(STATUS "Outside a virtual environment")
     execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; ';'.join(site.getsitepackages())"
+      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; print(';'.join(site.getsitepackages()))"
       OUTPUT_STRIP_TRAILING_WHITESPACE
       OUTPUT_VARIABLE path_list
     )

--- a/sherpa/cpp_api/bin/CMakeLists.txt
+++ b/sherpa/cpp_api/bin/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT WIN32)
       OUTPUT_VARIABLE path_list
     )
   else()
-    message(STATUS "Inside of a virtual environment")
+    message(STATUS "Inside a virtual environment")
     execute_process(
       COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
       OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/sherpa/cpp_api/bin/CMakeLists.txt
+++ b/sherpa/cpp_api/bin/CMakeLists.txt
@@ -14,33 +14,43 @@ if(SHERPA_ENABLE_PORTAUDIO)
   endif()
 endif()
 
-if(NOT WIN32)
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE PYTHON_SITE_PACKAGE_DIR
-  )
-  message(STATUS "PYTHON_SITE_PACKAGE_DIR: ${PYTHON_SITE_PACKAGE_DIR}")
-  target_link_libraries(sherpa-offline "-Wl,-rpath,${PYTHON_SITE_PACKAGE_DIR}/sherpa/lib")
-  target_link_libraries(sherpa-offline "-Wl,-rpath,${SHERPA_RPATH_ORIGIN}/../lib")
-
-  target_link_libraries(sherpa-online "-Wl,-rpath,${PYTHON_SITE_PACKAGE_DIR}/sherpa/lib")
-  target_link_libraries(sherpa-online "-Wl,-rpath,${SHERPA_RPATH_ORIGIN}/../lib")
-
-  if(SHERPA_ENABLE_PORTAUDIO)
-    target_link_libraries(sherpa-online-microphone "-Wl,-rpath,${PYTHON_SITE_PACKAGE_DIR}/sherpa/lib")
-    target_link_libraries(sherpa-online-microphone "-Wl,-rpath,${SHERPA_RPATH_ORIGIN}/../lib")
-  endif()
-endif()
-
-install(
-  TARGETS sherpa-offline sherpa-online
-  DESTINATION bin
+set(exe_list
+  sherpa-offline
+  sherpa-online
 )
 
 if(SHERPA_ENABLE_PORTAUDIO)
-  install(
-    TARGETS sherpa-online-microphone
-    DESTINATION bin
-  )
+  list(APPEND exe_list sherpa-online-microphone)
 endif()
+
+if(NOT WIN32)
+  if(NOT DEFINED ENV{VIRTUAL_ENV})
+    message(STATUS "Outside a virtual environment")
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; ';'.join(site.getsitepackages())"
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE path_list
+    )
+  else()
+    message(STATUS "Inside of a virtual environment")
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE PYTHON_SITE_PACKAGE_DIR
+    )
+    set(path_list ${PYTHON_SITE_PACKAGE_DIR})
+  endif()
+
+  message(STATUS "path list: ${path_list}")
+  foreach(p IN LISTS path_list)
+    foreach(exe IN LISTS exe_list)
+      target_link_libraries(${exe} "-Wl,-rpath,${p}/sherpa/lib")
+      target_link_libraries(${exe} "-Wl,-rpath,${p}/../lib")
+    endforeach()
+  endforeach()
+endif()
+
+install(
+  TARGETS ${exe_list}
+  DESTINATION bin
+)

--- a/sherpa/cpp_api/websocket/CMakeLists.txt
+++ b/sherpa/cpp_api/websocket/CMakeLists.txt
@@ -77,20 +77,33 @@ if(SHERPA_ENABLE_PORTAUDIO)
   list(APPEND bins sherpa-online-websocket-client-microphone)
 endif()
 
-foreach(exe IN LISTS bins)
-  if(NOT WIN32)
+if(NOT WIN32)
+  if(NOT DEFINED ENV{VIRTUAL_ENV})
+    message(STATUS "Outside a virtual environment")
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; ';'.join(site.getsitepackages())"
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE path_list
+    )
+  else()
+    message(STATUS "Inside a virtual environment")
     execute_process(
       COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
       OUTPUT_STRIP_TRAILING_WHITESPACE
       OUTPUT_VARIABLE PYTHON_SITE_PACKAGE_DIR
     )
-    message(STATUS "PYTHON_SITE_PACKAGE_DIR: ${PYTHON_SITE_PACKAGE_DIR}")
-    target_link_libraries(${exe} "-Wl,-rpath,${PYTHON_SITE_PACKAGE_DIR}/sherpa/lib")
-    target_link_libraries(${exe} "-Wl,-rpath,${SHERPA_RPATH_ORIGIN}/../lib")
+    set(path_list ${PYTHON_SITE_PACKAGE_DIR})
   endif()
 
-  install(TARGETS
-      ${exe}
-    DESTINATION  bin
-  )
-endforeach()
+  message(STATUS "path list: ${path_list}")
+  foreach(p IN LISTS path_list)
+    foreach(exe IN LISTS bins)
+      target_link_libraries(${exe} "-Wl,-rpath,${p}/sherpa/lib")
+      target_link_libraries(${exe} "-Wl,-rpath,${p}/../lib")
+    endforeach()
+  endforeach()
+endif()
+
+install(TARGETS ${bins}
+  DESTINATION  bin
+)

--- a/sherpa/cpp_api/websocket/CMakeLists.txt
+++ b/sherpa/cpp_api/websocket/CMakeLists.txt
@@ -81,7 +81,7 @@ if(NOT WIN32)
   if(NOT DEFINED ENV{VIRTUAL_ENV})
     message(STATUS "Outside a virtual environment")
     execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; ';'.join(site.getsitepackages())"
+      COMMAND "${PYTHON_EXECUTABLE}" -c "import site; print(';'.join(site.getsitepackages()))"
       OUTPUT_STRIP_TRAILING_WHITESPACE
       OUTPUT_VARIABLE path_list
     )


### PR DESCRIPTION
It throws the following error inside a colab notebook:

```
sherpa-offline: error while loading shared libraries: libsherpa_cpp_api.so: cannot open shared object file: No such file or directory
```

## Steps for fixing it
```
readelf -d /usr/local/bin/sherpa-offline
```

It prints:
```
Dynamic section at offset 0x228f0 contains 37 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libsherpa_cpp_api.so]
 0x0000000000000001 (NEEDED)             Shared library: [libsherpa_core.so]
 0x0000000000000001 (NEEDED)             Shared library: [libtorch_cpu.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc10.so]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libtorch.so]
 0x0000000000000001 (NEEDED)             Shared library: [libsherpa_kaldi_native_io_core.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/usr/local/lib/python3.8/dist-packages/torch/lib:/usr/local/lib/python3.8/dist-packages/k2/lib:/usr/local/lib/python3.8/dist-packages/kaldifeat/lib:/usr/lib/python3/dist-packages/sherpa/lib:$ORIGIN/../lib:$ORIGIN/k2/lib:$ORIGIN/k2/lib64:$ORIGIN/torch/lib:$ORIGIN/torch/lib64]
```

Runpath is
```
 0x000000000000001d (RUNPATH)            Library runpath: [
$ORIGIN:/usr/local/lib/python3.8/dist-packages/torch/lib:
/usr/local/lib/python3.8/dist-packages/k2/lib:
/usr/local/lib/python3.8/dist-packages/kaldifeat/lib:
/usr/lib/python3/dist-packages/sherpa/lib:$ORIGIN/../lib:
$ORIGIN/k2/lib:$ORIGIN/k2/lib64:$ORIGIN/torch/lib:$ORIGIN/torch/lib64]
```

```
import sherpa
print(sherpa.__file__)
```

It prints
```
/usr/local/lib/python3.8/dist-packages/sherpa/__init__.py
```

```
ls /usr/lib/python3/dist-packages/sherpa/
```
prints
```
ls: cannot access '/usr/lib/python3/dist-packages/sherpa/': No such file or directory
```

---

```
ls /usr/local/lib/python3.8/dist-packages/sherpa/lib
```

```
libsherpa_core.so     libsherpa_kaldi_native_io_core.so
libsherpa_cpp_api.so  libsherpa_portaudio.so
```

We are setting the rpath `/usr/lib/python3/dist-packages/sherpa/lib` in the `.so` file instead of
`/usr/local/lib/python3.8/dist-packages/sherpa/lib`.

The reason is that colab does not use a virtual environment and it installs packages  in a location
that is not handled by `CMakeLists.txt`.

This PR fixes that.

