### PR TITLE
Prevent cmake from trying to link with system MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,10 @@ endif()
 
 include(pybind11)
 include(json)
+# to prevent cmake from trying to link with system installed mkl since we not directly use it
+# mkl libraries should be linked with pytorch already
+# ref: https://github.com/pytorch/pytorch/blob/master/cmake/public/mkl.cmake
+set(CMAKE_DISABLE_FIND_PACKAGE_MKL TRUE)
 include(torch)
 include(k2)
 include(kaldifeat)


### PR DESCRIPTION
If a computer has mkl installed in default location (/opt/intel/.../mkl) and this location is not in library search path, the build process will be failed due to pytorch cmake config.
This will prevent cmake from searching for system MKL since it is installed alongside with pytorch already