### PR TITLE
fix a few scripts for building (issue #290)

### DIFF
--- a/sherpa/csrc/online-conformer-transducer-model.cc
+++ b/sherpa/csrc/online-conformer-transducer-model.cc
@@ -119,7 +119,7 @@ OnlineConformerTransducerModel::RunEncoder(
   auto projected_encoder_out =
       encoder_proj_.run_method("forward", encoder_out).toTensor();
 
-  return {projected_encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(projected_encoder_out, encoder_out_length, next_states);
 }
 
 torch::Tensor OnlineConformerTransducerModel::RunDecoder(

--- a/sherpa/csrc/online-conv-emformer-transducer-model.cc
+++ b/sherpa/csrc/online-conv-emformer-transducer-model.cc
@@ -223,7 +223,7 @@ OnlineConvEmformerTransducerModel::RunEncoder(
   auto projected_encoder_out =
       encoder_proj_.run_method("forward", encoder_out).toTensor();
 
-  return {projected_encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(projected_encoder_out, encoder_out_length, next_states); 
 }
 
 torch::Tensor OnlineConvEmformerTransducerModel::RunDecoder(

--- a/sherpa/csrc/online-emformer-transducer-model.cc
+++ b/sherpa/csrc/online-emformer-transducer-model.cc
@@ -158,7 +158,7 @@ OnlineEmformerTransducerModel::RunEncoder(
   torch::Tensor encoder_out_length = tuple_ptr->elements()[1].toTensor();
   torch::IValue next_states = tuple_ptr->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states); 
 }
 
 torch::Tensor OnlineEmformerTransducerModel::RunDecoder(

--- a/sherpa/csrc/online-lstm-transducer-model.cc
+++ b/sherpa/csrc/online-lstm-transducer-model.cc
@@ -115,7 +115,7 @@ OnlineLstmTransducerModel::RunEncoder(
 
   auto next_states = tuple_ptr->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::Tensor OnlineLstmTransducerModel::RunDecoder(

--- a/sherpa/csrc/online-zipformer-transducer-model.cc
+++ b/sherpa/csrc/online-zipformer-transducer-model.cc
@@ -221,7 +221,7 @@ OnlineZipformerTransducerModel::RunEncoder(
 
   auto next_states = tuple_ptr->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::Tensor OnlineZipformerTransducerModel::RunDecoder(

--- a/sherpa/csrc/rnnt_conformer_model.cc
+++ b/sherpa/csrc/rnnt_conformer_model.cc
@@ -153,7 +153,7 @@ RnntConformerModel::StreamingForwardEncoder(
 
   auto next_states = outputs->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::Tensor RnntConformerModel::ForwardDecoder(

--- a/sherpa/csrc/rnnt_conv_emformer_model.cc
+++ b/sherpa/csrc/rnnt_conv_emformer_model.cc
@@ -233,7 +233,8 @@ RnntConvEmformerModel::StreamingForwardEncoder(
 
   torch::Tensor encoder_out_length = tuple_ptr->elements()[1].toTensor();
   torch::IValue next_states = tuple_ptr->elements()[2];
-  return {encoder_out, encoder_out_length, next_states};
+
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::IValue RnntConvEmformerModel::GetEncoderInitStates(

--- a/sherpa/csrc/rnnt_emformer_model.cc
+++ b/sherpa/csrc/rnnt_emformer_model.cc
@@ -66,7 +66,7 @@ RnntEmformerModel::StreamingForwardEncoder(
   torch::Tensor encoder_out_length = tuple_ptr->elements()[1].toTensor();
   torch::IValue next_states = tuple_ptr->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::IValue RnntEmformerModel::GetEncoderInitStates(int32_t /*unused=1*/) {

--- a/sherpa/csrc/rnnt_lstm_model.cc
+++ b/sherpa/csrc/rnnt_lstm_model.cc
@@ -83,7 +83,7 @@ RnntLstmModel::StreamingForwardEncoder(
 
   auto next_states = tuple_ptr->elements()[2];
 
-  return {encoder_out, encoder_out_length, next_states};
+  return std::make_tuple(encoder_out, encoder_out_length, next_states);
 }
 
 torch::IValue RnntLstmModel::StateToIValue(const State &s) const {

--- a/sherpa/python/csrc/rnnt_beam_search.cc
+++ b/sherpa/python/csrc/rnnt_beam_search.cc
@@ -157,7 +157,7 @@ void PybindRnntBeamSearch(py::module &m) {  // NOLINT
         decoder_out = StreamingGreedySearch(
             model, encoder_out, decoder_out, frame_offset, &hyps,
             &num_trailing_blank_frames, &timestamps);
-        return {decoder_out, hyps, num_trailing_blank_frames, timestamps};
+        return std::make_tuple(decoder_out, hyps, num_trailing_blank_frames, timestamps);
       },
       py::arg("model"), py::arg("encoder_out"), py::arg("decoder_out"),
       py::arg("hyps"), py::arg("num_trailing_blank_frames"),

--- a/sherpa/python/csrc/rnnt_conformer_model.cc
+++ b/sherpa/python/csrc/rnnt_conformer_model.cc
@@ -63,8 +63,8 @@ void PybindRnntConformerModel(py::module &m) {  // NOLINT
                 self.StreamingForwardEncoder(features, features_length,
                                              processed_frames,
                                              self.StateToIValue(states));
-            return {encoder_out, encoder_out_lens,
-                    self.StateFromIValue(next_states)};
+            return std::make_tuple(encoder_out, encoder_out_lens,
+                    self.StateFromIValue(next_states));
           },
           py::arg("features"), py::arg("features_length"), py::arg("states"),
           py::arg("processed_frames"), py::call_guard<py::gil_scoped_release>())

--- a/sherpa/python/csrc/rnnt_conv_emformer_model.cc
+++ b/sherpa/python/csrc/rnnt_conv_emformer_model.cc
@@ -59,8 +59,8 @@ void PybindRnntConvEmformerModel(py::module &m) {  // NOLINT
                                              num_processed_frames,
                                              self.StateToIValue(states));
 
-            return {encoder_out, encoder_out_lens,
-                    self.StateFromIValue(next_states)};
+            return std::make_tuple(encoder_out, encoder_out_lens,
+                    self.StateFromIValue(next_states));
           },
           py::arg("features"), py::arg("features_length"),
           py::arg("num_processed_frames"), py::arg("states"),

--- a/sherpa/python/csrc/rnnt_emformer_model.cc
+++ b/sherpa/python/csrc/rnnt_emformer_model.cc
@@ -57,8 +57,8 @@ void PybindRnntEmformerModel(py::module &m) {  // NOLINT
                 self.StreamingForwardEncoder(features, features_length, {},
                                              self.StateToIValue(states));
 
-            return {encoder_out, encoder_out_lens,
-                    self.StateFromIValue(next_states)};
+            return std::make_tuple(encoder_out, encoder_out_lens,
+                    self.StateFromIValue(next_states));
           },
           py::arg("features"), py::arg("features_length"),
           py::arg("states") = py::none(),

--- a/sherpa/python/csrc/rnnt_lstm_model.cc
+++ b/sherpa/python/csrc/rnnt_lstm_model.cc
@@ -61,8 +61,8 @@ void PybindRnntLstmModel(py::module &m) {  // NOLINT
                 self.StreamingForwardEncoder(features, features_length, {},
                                              self.StateToIValue(states));
 
-            return {encoder_out, encoder_out_lens,
-                    self.StateFromIValue(next_states)};
+            return std::make_tuple(encoder_out, encoder_out_lens,
+                    self.StateFromIValue(next_states));
           },
           py::arg("features"), py::arg("features_length"), py::arg("states"),
           py::call_guard<py::gil_scoped_release>())


### PR DESCRIPTION

This fix is relevant to #290 . Basically it replaced a lot of `return {*}` with `return std::make_tuple()` for building.

These changes made building successful under environment: 
* torch 1.9.0, cuda 10.2, gcc 5.4.0
* k2 1.23.4.dev20230130+cuda10.2.torch1.9.0