### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/sherpa/cpp_api/CMakeLists.txt
+++ b/sherpa/cpp_api/CMakeLists.txt
@@ -9,6 +9,10 @@ set(sherpa_cpp_api_srcs
 add_library(sherpa_cpp_api ${sherpa_cpp_api_srcs})
 target_link_libraries(sherpa_cpp_api sherpa_core)
 
+if(UNIT AND NOT APPLE)
+  target_link_libraries(sherpa_cpp_api sherpa_core pthread)
+endif()
+
 if(SHERPA_ENABLE_TESTS)
   add_executable(test-feature-config test-feature-config.cc)
   target_link_libraries(test-feature-config sherpa_cpp_api)

--- a/sherpa/cpp_api/CMakeLists.txt
+++ b/sherpa/cpp_api/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(sherpa_cpp_api ${sherpa_cpp_api_srcs})
 target_link_libraries(sherpa_cpp_api sherpa_core)
 
 if(UNIT AND NOT APPLE)
-  target_link_libraries(sherpa_cpp_api sherpa_core pthread)
+  target_link_libraries(sherpa_cpp_api sherpa_core -pthread)
 endif()
 
 if(SHERPA_ENABLE_TESTS)

--- a/sherpa/cpp_api/CMakeLists.txt
+++ b/sherpa/cpp_api/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(sherpa_cpp_api ${sherpa_cpp_api_srcs})
 target_link_libraries(sherpa_cpp_api sherpa_core)
 
 if(UNIT AND NOT APPLE)
-  target_link_libraries(sherpa_cpp_api sherpa_core -pthread)
+  target_link_libraries(sherpa_cpp_api -pthread)
 endif()
 
 if(SHERPA_ENABLE_TESTS)


### PR DESCRIPTION
解决找不到libpthread.so.0的问题。
报错信息：
/usr/bin/ld: CMakeFiles/sherpa-offline.dir/offline-recognizer.cc.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5' /usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line collect2: error: ld returned 1 exit status