### PR TITLE
Fix riscv64 docs

### DIFF
--- a/docs/source/ncnn/install/riscv64-embedded-linux.rst
+++ b/docs/source/ncnn/install/riscv64-embedded-linux.rst
@@ -75,7 +75,7 @@ the generated binaries.
 
     .. code-block:: bash
 
-      ./sherpa-ncnn-alsa \
+      ./sherpa-ncnn \
         ./sherpa-ncnn-streaming-zipformer-small-bilingual-zh-en-2023-02-16/tokens.txt \
         ./sherpa-ncnn-streaming-zipformer-small-bilingual-zh-en-2023-02-16/64/encoder_jit_trace-pnnx.ncnn.param \
         ./sherpa-ncnn-streaming-zipformer-small-bilingual-zh-en-2023-02-16/64/encoder_jit_trace-pnnx.ncnn.bin \


### PR DESCRIPTION
We should use `sherpa-ncnn` to decode wave files, not `sherpa-ncnn-alsa`.