### PR TITLE
Fix a document for icefall-asr-librispeech-streaming-zipformer-2023-05-17

### DIFF
--- a/docs/source/cpp/pretrained_models/online_transducer.rst
+++ b/docs/source/cpp/pretrained_models/online_transducer.rst
@@ -39,6 +39,7 @@ icefall-asr-librispeech-streaming-zipformer-2023-05-17
   cd icefall-asr-librispeech-streaming-zipformer-2023-05-17
 
   git lfs pull --include "exp/jit_script_chunk_16_left_128.pt"
+  git lfs pull --include "data/lang_bpe_500/LG.pt"
 
   for m in greedy_search modified_beam_search fast_beam_search; do
     sherpa-online \


### PR DESCRIPTION
The current document for using `icefall-asr-librispeech-streaming-zipformer-2023-05-17` lacks downloading `LG.pt`.
This pull request fixes that.