### PR TITLE
Update cmake to cpp 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ version to be used.")
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")
+endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(SHERPA_ENABLE_TESTS "Whether to build tests" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ version to be used.")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ version to be used.")
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(SHERPA_ENABLE_TESTS "Whether to build tests" OFF)

--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import setuptools
 from setuptools.command.build_ext import build_ext
-
+import torch
 
 def is_for_pypi():
     ans = os.environ.get("SHERPA_IS_FOR_PYPI", None)
@@ -22,6 +22,11 @@ def is_macos():
 
 def is_windows():
     return platform.system() == "Windows"
+
+
+def get_pytorch_version():
+    # if it is 1.7.1+cuda101, then strip +cuda101
+    return torch.__version__.split("+")[0]
 
 
 try:
@@ -76,6 +81,12 @@ class BuildExtension(build_ext):
         if "PYTHON_EXECUTABLE" not in cmake_args:
             print(f"Setting PYTHON_EXECUTABLE to {sys.executable}")
             cmake_args += f" -DPYTHON_EXECUTABLE={sys.executable}"
+
+        major, minor = get_pytorch_version().split(".")[:2]
+        major = int(major)
+        minor = int(minor)
+        if major == 2 and minor >= 1:
+            extra_cmake_args += f" -DCMAKE_CXX_STANDARD=17 "
 
         cmake_args += extra_cmake_args
 


### PR DESCRIPTION
I was tried building sherpa from source with torch 2.1 but failed with the following error:

```
#error C++17 or later compatible compiler is required to use PyTorch
```

Fixing changing the cpp version in the cmkae file did the trick