### PR TITLE
Add Android APKs for speaker identification.

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -67,8 +67,10 @@ jobs:
           cd huggingface
           ./generate-tts.py
           ./generate-tts-engine.py
+          ./generate-speaker-identification.py
           mv -v apk.html ../build/html/onnx/tts/
           mv -v apk-engine.html ../build/html/onnx/tts/
+          mv -v apk-speaker-identification.html ../build/html/onnx/speaker-identification/apk.html
           cd ..
           rm -rf huggingface
 

--- a/docs/source/onnx/index.rst
+++ b/docs/source/onnx/index.rst
@@ -37,6 +37,12 @@ Also, we show how to use it for speech recognition with pre-trained models.
 
 .. toctree::
    :maxdepth: 5
+   :caption: Speaker Identification
+
+   ./speaker-identification/index
+
+.. toctree::
+   :maxdepth: 5
    :caption: tts
 
    ./tts/index

--- a/docs/source/onnx/speaker-identification/index.rst
+++ b/docs/source/onnx/speaker-identification/index.rst
@@ -1,0 +1,16 @@
+Speaker Identification
+======================
+
+This page describes how to use `sherpa-onnx`_ for speaker identification.
+
+Please first follow :ref:`install_sherpa_onnx` and/or :ref:`install_sherpa_onnx_python`
+to install `sherpa-onnx`_ before you continue.
+
+
+Pre-trained models can be found at `<https://github.com/k2-fsa/sherpa-onnx/releases/tag/speaker-recongition-models>`_
+
+.. hint::
+
+   You can find Android APKs for each model at the following page
+
+   `<https://k2-fsa.github.io/sherpa/onnx/speaker-identification/apk.html>`_


### PR DESCRIPTION
You can find pre-built Android APKs for speaker identification at

https://k2-fsa.github.io/sherpa/onnx/speaker-identification/apk.html

A screenshot is given below:
![image](https://github.com/k2-fsa/sherpa/assets/5284924/265152a4-b509-46dd-a561-01441607e45f)
