### PR TITLE
Add github model links for keyword-spotting

### DIFF
--- a/docs/source/onnx/kws/pretrained_models/index.rst
+++ b/docs/source/onnx/kws/pretrained_models/index.rst
@@ -32,12 +32,25 @@ Download the model
 
 Please use the following commands to download it.
 
-.. code-block:: bash
+.. tabs::
 
-  cd /path/to/sherpa-onnx
-  git lfs install
-  git clone https://www.modelscope.cn/pkufool/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.git
-  ls -lh sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01
+   .. tab:: Github
+
+      .. code-block:: bash
+
+        cd /path/to/sherpa-onnx
+        wget -qq https://github.com/pkufool/keyword-spotting-models/releases/download/v0.1/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz 
+        tar jxvf sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz
+        ls -lh sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01
+
+   .. tab:: ModelScope
+
+      .. code-block:: bash
+
+        cd /path/to/sherpa-onnx
+        git lfs install
+        git clone https://www.modelscope.cn/pkufool/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.git
+        ls -lh sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01
 
 The output is given below:
 
@@ -228,12 +241,25 @@ Download the model
 
 Please use the following commands to download it.
 
-.. code-block:: bash
+.. tabs::
 
-  cd /path/to/sherpa-onnx
-  git lfs install
-  git clone https://www.modelscope.cn/pkufool/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.git
-  ls -lh sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01
+   .. tab:: Github
+
+      .. code-block:: bash
+
+        cd /path/to/sherpa-onnx
+        wget -qq https://github.com/pkufool/keyword-spotting-models/releases/download/v0.1/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz 
+        tar jxvf sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz
+        ls -lh sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01
+
+   .. tab:: ModelScope
+
+      .. code-block:: bash
+
+        cd /path/to/sherpa-onnx
+        git lfs install
+        git clone https://www.modelscope.cn/pkufool/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.git
+        ls -lh sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01
 
 The output is given below:
 

--- a/docs/source/onnx/kws/pretrained_models/index.rst
+++ b/docs/source/onnx/kws/pretrained_models/index.rst
@@ -40,7 +40,7 @@ Please use the following commands to download it.
 
         cd /path/to/sherpa-onnx
         wget -qq https://github.com/pkufool/keyword-spotting-models/releases/download/v0.1/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz 
-        tar jxvf sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz
+        tar xf sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.tar.bz
         ls -lh sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01
 
    .. tab:: ModelScope
@@ -249,7 +249,7 @@ Please use the following commands to download it.
 
         cd /path/to/sherpa-onnx
         wget -qq https://github.com/pkufool/keyword-spotting-models/releases/download/v0.1/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz 
-        tar jxvf sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz
+        tar xf sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.tar.bz
         ls -lh sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01
 
    .. tab:: ModelScope


### PR DESCRIPTION
I add github links as an option, I will keep modelscope links as it is. For now in China mainland, we usually have weak connection to github and huggingface, the ModelScope is indeed the most suitable place to hold models for Chinese users.  I think we should care about not only the users who ask questions, but also the users (I think they are more) who don't, host models on ModelScope will benetfit a lot of Chinese users, anyway, that is my opinion.