### PR TITLE
Replace FbankOptions with FeatureConfig to support 'normalize_samples' option

### DIFF
--- a/sherpa/cpp_api/online-recognizer.cc
+++ b/sherpa/cpp_api/online-recognizer.cc
@@ -347,7 +347,7 @@ class OnlineRecognizer::OnlineRecognizerImpl {
   }
 
   std::unique_ptr<OnlineStream> CreateStream() {
-    auto s = std::make_unique<OnlineStream>(config_.feat_config.fbank_opts);
+    auto s = std::make_unique<OnlineStream>(config_.feat_config);
     InitOnlineStream(s.get());
     return s;
   }
@@ -359,7 +359,7 @@ class OnlineRecognizer::OnlineRecognizerImpl {
     // model rather than each stream.
     auto context_graph =
         std::make_shared<ContextGraph>(contexts, config_.context_score);
-    auto s = std::make_unique<OnlineStream>(config_.feat_config.fbank_opts,
+    auto s = std::make_unique<OnlineStream>(config_.feat_config,
                                             context_graph);
     InitOnlineStream(s.get());
     return s;

--- a/sherpa/cpp_api/online-stream.h
+++ b/sherpa/cpp_api/online-stream.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "kaldifeat/csrc/feature-fbank.h"
+#include "sherpa/cpp_api/feature-config.h"
 #include "sherpa/csrc/context-graph.h"
 #include "torch/script.h"
 
@@ -58,7 +58,7 @@ struct OnlineTransducerDecoderResult;
 
 class OnlineStream {
  public:
-  explicit OnlineStream(const kaldifeat::FbankOptions &opts,
+  explicit OnlineStream(const FeatureConfig &feat_config,
                         ContextGraphPtr context_graph = nullptr);
   ~OnlineStream();
 

--- a/sherpa/csrc/test-online-stream.cc
+++ b/sherpa/csrc/test-online-stream.cc
@@ -32,7 +32,7 @@ TEST(OnlineStream, Test) {
   FeatureConfig feat_config;
   feat_config.fbank_opts.mel_opts.num_bins = feature_dim;
 
-  OnlineStream s(feat_config.fbank_opts);
+  OnlineStream s(feat_config);
   EXPECT_EQ(s.NumFramesReady(), 0);
   auto a = torch::rand({500}, torch::kFloat);
   s.AcceptWaveform(sampling_rate, a);


### PR DESCRIPTION
By setting --normalize-samples=false, you can invoke the model trained with Kaldi-style features.

Note: sherpa-offline supports setting this option from the command line, while sherpa-online does not support it. This PR is to enable command line setting support for sherpa-online.

Note 2: There are no changes related to pybind, server/client, triton (maybe) submitted here. If you think that 'Replace FbankOptions with FeatureConfig' is worth it (for this requirement or in the future), I am willing to make the necessary changes.