### PR TITLE
Support --context-size=1

### DIFF
--- a/sherpa/csrc/online-lstm-transducer-model.cc
+++ b/sherpa/csrc/online-lstm-transducer-model.cc
@@ -27,7 +27,9 @@ OnlineLstmTransducerModel::OnlineLstmTransducerModel(
   joiner_.eval();
 
   context_size_ =
-      decoder_.attr("conv").toModule().attr("weight").toTensor().size(2);
+      decoder_.hasattr("conv")
+          ? decoder_.attr("conv").toModule().attr("weight").toTensor().size(2)
+          : 1;
 
   // Use 5 here since the subsampling is ((len - 3) // 2 - 1) // 2.
   int32_t pad_length = 5;

--- a/sherpa/csrc/online-zipformer-transducer-model.cc
+++ b/sherpa/csrc/online-zipformer-transducer-model.cc
@@ -27,7 +27,9 @@ OnlineZipformerTransducerModel::OnlineZipformerTransducerModel(
   joiner_.eval();
 
   context_size_ =
-      decoder_.attr("conv").toModule().attr("weight").toTensor().size(2);
+      decoder_.hasattr("conv")
+          ? decoder_.attr("conv").toModule().attr("weight").toTensor().size(2)
+          : 1;
 
   // Use 7 here since the subsampling is ((len - 7) // 2 + 1) // 2.
   int32_t pad_length = 7;

--- a/sherpa/csrc/online-zipformer2-transducer-model.cc
+++ b/sherpa/csrc/online-zipformer2-transducer-model.cc
@@ -24,7 +24,9 @@ OnlineZipformer2TransducerModel::OnlineZipformer2TransducerModel(
   joiner_ = model_.attr("joiner").toModule();
 
   context_size_ =
-      decoder_.attr("conv").toModule().attr("weight").toTensor().size(2);
+      decoder_.hasattr("conv")
+          ? decoder_.attr("conv").toModule().attr("weight").toTensor().size(2)
+          : 1;
 
   int32_t pad_length = encoder_.attr("pad_length").toInt();
 


### PR DESCRIPTION
When --context-size is 1, there is no conv module at all.

It fixes the following error
```
[I] /xxxx/sherpa/cpp_api/bin/online-recognizer.cc:143:int32_t main(int32_t, char**) 2024-04-08 14:07:07.958 decoding method: greedy_search
terminate called after throwing an instance of 'torch::jit::ObjectAttributeError'
  what():  __torch__.torch.nn.modules.linear.Identity (of Python compilation unit at: 0x556bd40) does not have a field with name 'weight'
```