### PR TITLE
Doc: Add Android APKs for audio tagging

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -86,9 +86,11 @@ jobs:
               ./generate-tts.py
               ./generate-tts-engine.py
               ./generate-speaker-identification.py
+              ./generate-audio-tagging.py
               mv -v apk.html ../build/html/onnx/tts/
               mv -v apk-engine.html ../build/html/onnx/tts/
               mv -v apk-speaker-identification.html ../build/html/onnx/speaker-identification/apk.html
+              mv -v apk-audio-tagging.html ../build/html/onnx/audio-tagging/apk.html
               cd ..
               rm -rf huggingface
 

--- a/docs/source/onnx/android/build-sherpa-onnx.rst
+++ b/docs/source/onnx/android/build-sherpa-onnx.rst
@@ -37,6 +37,8 @@ and ``text-to-speech`` (TTS).
     - ``SherpaOnnxTtsEngine``  (this is for text-to-speech)
     - ``SherpaOnnxVad``
     - ``SherpaOnnxVadAsr``
+    - ``SherpaOnnxSpeakerIdentification``
+    - ``SherpaOnnxAudioTagging``
 
 
 Install Android Studio

--- a/docs/source/onnx/audio-tagging/android.rst
+++ b/docs/source/onnx/audio-tagging/android.rst
@@ -1,0 +1,8 @@
+Android
+=======
+
+You can find Android APKs for each model at the following page
+
+  `<https://k2-fsa.github.io/sherpa/onnx/audio-tagging/apk.html>`_
+
+Please follow :ref:`sherpa-onnx-android` to build Android APKs from source.

--- a/docs/source/onnx/audio-tagging/index.rst
+++ b/docs/source/onnx/audio-tagging/index.rst
@@ -9,3 +9,4 @@ its temporal localization.
    :maxdepth: 5
 
    ./pretrained_models.rst
+   ./android.rst


### PR DESCRIPTION
Prebuilt android APKs for audio tagging are available at

https://k2-fsa.github.io/sherpa/onnx/audio-tagging/apk.html