### PR TITLE
fix doc error in example command

### DIFF
--- a/docs/source/onnx/install/aarch64-embedded-linux.rst
+++ b/docs/source/onnx/install/aarch64-embedded-linux.rst
@@ -200,10 +200,10 @@ sherpa-onnx-alsa
     .. code-block:: bash
 
       ./sherpa-onnx-alsa \
-        --encoder=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/tokens.txt \
-        --decoder=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/encoder-epoch-99-avg-1.onnx \
-        --joiner=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/decoder-epoch-99-avg-1.onnx \
-        --tokens./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/joiner-epoch-99-avg-1.onnx \
+        --encoder=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/encoder-epoch-99-avg-1.onnx \
+        --decoder=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/decoder-epoch-99-avg-1.onnx \
+        --joiner=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/joiner-epoch-99-avg-1.onnx \
+        --tokens=./sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/tokens.txt \
         plughw:3,0
 
   Please change the card number and also the device index on the selected card


### PR DESCRIPTION
paths are mis-ordered respect to args