### PR TITLE
Fixed the problem that the duplicated characters would be merged as one.

### DIFF
--- a/sherpa/csrc/offline-ctc-one-best-decoder.cc
+++ b/sherpa/csrc/offline-ctc-one-best-decoder.cc
@@ -50,6 +50,8 @@ std::vector<OfflineCtcDecoderResult> OfflineCtcOneBestDecoder::Decode(
 
   OfflineCtcDecoderResult *p = results.data();
 
+  bool last_token_is_blank = false;
+
   for (int32_t i = 0, t = 0; i != labels.numel(); ++i) {
     int32_t token = acc[i];
 
@@ -63,9 +65,10 @@ std::vector<OfflineCtcDecoderResult> OfflineCtcOneBestDecoder::Decode(
 
     if (token == 0) {
       ++t;
+      last_token_is_blank = true;
       continue;
     }
-    if (t != 0 && !p->tokens.empty() && token == p->tokens.back()) {
+    if (t != 0 && !p->tokens.empty() && token == p->tokens.back() && (!last_token_is_blank)) {
       // This is a repeat, skip it.
       ++t;
       continue;
@@ -74,6 +77,7 @@ std::vector<OfflineCtcDecoderResult> OfflineCtcOneBestDecoder::Decode(
     p->tokens.push_back(token);
     p->timestamps.push_back(t);
     ++t;
+    last_token_is_blank = false;
   }  // for (int32_t i = 0, t = 0; i != labels.numel(); ++i)
 
   return results;


### PR DESCRIPTION
原来的第68行
```cpp
if (t != 0 && !p->tokens.empty() && token == p->tokens.back())
```
没有判断输出字符是否被blank分隔，导致相邻的重复字符会被合并为一个。
添加了变量`bool last_token_is_blank`作为标志位来判断是否被blank分隔，修复了这个问题。