### PR TITLE
Add doc for ASR TDT CTC models from NeMo

### DIFF
--- a/docs/source/onnx/pretrained_models/offline-ctc/index.rst
+++ b/docs/source/onnx/pretrained_models/offline-ctc/index.rst
@@ -4,7 +4,7 @@ Offline CTC models
 This section lists available offline CTC models.
 
 .. toctree::
-   :maxdepth: 7
+   :maxdepth: 8
 
    icefall/index
    nemo/index

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/code-english/tdt-ctc-110m-int8.txt
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/code-english/tdt-ctc-110m-int8.txt
@@ -1,0 +1,14 @@
+/project/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-offline --nemo-ctc-model=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/model.int8.onnx --tokens=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/tokens.txt ./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/test_wavs/0.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model="./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/model.int8.onnx"), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), telespeech_ctc="", tokens="./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/tokens.txt", num_threads=2, debug=False, provider="cpu", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+Done!
+
+./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/test_wavs/0.wav
+{"lang": "", "emotion": "", "event": "", "text": " Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait.", "timestamps": [0.48, 0.64, 0.80, 0.88, 0.96, 1.04, 1.12, 1.20, 1.36, 1.44, 1.60, 1.76, 1.92, 2.08, 2.24, 2.32, 2.40, 2.56, 2.64, 2.80, 2.88, 2.96, 3.04, 3.28, 3.44, 3.60, 3.76, 4.00, 4.16, 4.24, 4.40, 4.80, 5.04, 5.20, 5.36, 5.52, 5.68, 5.84, 6.08, 6.32, 6.48, 6.72, 6.80, 6.88, 7.04, 7.36], "tokens":[" Well", ",", " I", " don", "'", "t", " w", "ish", " to", " see", " it", " any", " more", ",", " o", "bs", "er", "ved", " P", "h", "o", "e", "be", ",", " turn", "ing", " away", " her", " e", "y", "es", ".", " It", " is", " c", "ertain", "ly", " very", " like", " the", " old", " p", "ort", "ra", "it", "."], "words": []}
+----
+num threads: 2
+decoding method: greedy_search
+Elapsed seconds: 0.487 s
+Real time factor (RTF): 0.487 / 7.435 = 0.066

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/code-japanese/tdt-ctc-0.6b-int8.txt
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/code-japanese/tdt-ctc-0.6b-int8.txt
@@ -1,0 +1,18 @@
+/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 ./build/bin/sherpa-onnx-offline --nemo-ctc-model=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/model.int8.onnx --tokens=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/tokens.txt ./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/test_wavs/test_ja_1.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model="./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/model.int8.onnx"), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/tokens.txt", num_threads=2, debug=False, provider="cpu", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-stream.cc:AcceptWaveformImpl:164 Creating a resampler:
+   in_sample_rate: 48000
+   output_sample_rate: 16000
+
+Done!
+
+./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/test_wavs/test_ja_1.wav
+{"lang": "", "emotion": "", "event": "", "text": " 日本語ちゃんと聞っとえてますか?ちゃんと聞こえてんの?ちゃんと聞こえてんの?ってマイクを持ってもらって", "timestamps": [0.00, 1.04, 1.36, 1.60, 1.68, 1.84, 2.08, 2.24, 2.48, 2.64, 4.72, 4.96, 5.20, 5.44, 5.60, 5.76, 6.00, 6.08, 8.08, 8.24, 8.48, 8.72, 8.88, 9.12, 9.36, 9.44, 10.80, 11.04, 11.36, 11.60, 11.68, 11.84, 12.00, 12.16, 12.24, 12.40, 12.56], "tokens":[" ", "日本", "語", "ちゃん", "と", "聞", "っと", "えて", "ます", "か", "?", "ちゃん", "と", "聞", "こ", "えて", "ん", "の", "?", "ちゃん", "と", "聞", "こ", "えて", "ん", "の", "?", "って", "マ", "イ", "ク", "を", "持", "って", "も", "ら", "って"], "words": []}
+----
+num threads: 2
+decoding method: greedy_search
+Elapsed seconds: 1.375 s
+Real time factor (RTF): 1.375 / 13.000 = 0.106

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/english.rst
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/english.rst
@@ -17,6 +17,89 @@ English
 
 This page lists offline CTC models from `NeMo`_ for English.
 
+sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000 (English, 英语)
+----------------------------------------------------------------
+
+This model is converted from `<https://hugginface.co/nvidia/parakeet-tdt_ctc-110m>`_.
+
+You can find the code for exporting the model from `NeMo`_ to `sherpa-onnx`_
+`<https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/nemo/fast-conformer-hybrid-transducer-ctc>`_.
+
+It supports both punctuations and cases.
+
+In the following, we describe how to download it and use it with `sherpa-onnx`_.
+
+Download the model
+~~~~~~~~~~~~~~~~~~
+
+Please use the following commands to download it.
+
+.. code-block:: bash
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2
+   tar xvf sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2
+   rm sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2
+
+You should see something like below after downloading::
+
+  ls -lh sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8
+
+  total 126M
+  -rw-r--r-- 1 501 staff 126M Jul  8 12:23 model.int8.onnx
+  drwxr-xr-x 2 501 staff 4.0K Jul  8 12:26 test_wavs
+  -rw-r--r-- 1 501 staff 9.8K Jul  8 12:22 tokens.txt
+
+Decode wave files
+~~~~~~~~~~~~~~~~~
+
+.. hint::
+
+   It supports decoding only wave files of a single channel with 16-bit
+   encoded samples, while the sampling rate does not need to be 16 kHz.
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  ./build/bin/sherpa-onnx-offline \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/tokens.txt \
+    ./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/test_wavs/0.wav
+
+.. note::
+
+   Please use ``./build/bin/Release/sherpa-onnx-offline.exe`` for Windows.
+
+You should see the following output:
+
+.. literalinclude:: ./code-english/tdt-ctc-110m-int8.txt
+
+Speech recognition from a microphone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  ./build/bin/sherpa-onnx-microphone-offline \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/tokens.txt
+
+Speech recognition from a microphone with VAD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx
+
+  ./build/bin/sherpa-onnx-vad-microphone-offline-asr \
+    --silero-vad-model=./silero_vad.onnx \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8/tokens.txt
+
+
 stt_en_citrinet_512
 -------------------
 

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/index.rst
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/index.rst
@@ -11,7 +11,7 @@ This page lists all offline CTC models from `NeMo`_.
    for a list of pre-trained NeMo models.
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 7
 
    how-to-export
    english

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/index.rst
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/index.rst
@@ -14,3 +14,4 @@ This page lists all offline CTC models from `NeMo`_.
    how-to-export
    english
    russian
+   japanese

--- a/docs/source/onnx/pretrained_models/offline-ctc/nemo/japanese.rst
+++ b/docs/source/onnx/pretrained_models/offline-ctc/nemo/japanese.rst
@@ -1,0 +1,101 @@
+Japanese
+========
+
+.. hint::
+
+   Please refer to :ref:`install_sherpa_onnx` to install `sherpa-onnx`_
+   before you read this section.
+
+This page lists offline CTC models from `NeMo`_ for Japanese.
+
+sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8 (Japanese, 日语)
+------------------------------------------------------------------------
+
+This model is converted from `<https://hugginface.co/nvidia/parakeet-tdt_ctc-0.6b-ja>`_.
+
+You can find the code for exporting the model from `NeMo`_ to `sherpa-onnx`_
+at `<https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/nemo/parakeet-tdt_ctc-0.6b-ja>`_.
+
+The model was trained on `ReazonSpeech`_ v2.0 speech corpus containing more than 35k
+hours of natural Japanese speech.
+
+In the following, we describe how to download it and use it with `sherpa-onnx`_.
+
+Download the model
+~~~~~~~~~~~~~~~~~~
+
+Please use the following commands to download it.
+
+.. code-block:: bash
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8.tar.bz2
+   tar xvf sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8.tar.bz2
+   rm sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8.tar.bz2
+
+You should see something like below after downloading::
+
+  ls -lh sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/
+  total 1310808
+  -rw-r--r--  1 fangjun  staff   625M Jul  9 11:11 model.int8.onnx
+  drwxr-xr-x  5 fangjun  staff   160B Jul  9 14:22 test_wavs
+  -rw-r--r--  1 fangjun  staff    28K Jul  9 14:21 tokens.txt
+
+Decode wave files
+~~~~~~~~~~~~~~~~~
+
+.. hint::
+
+   It supports decoding only wave files of a single channel with 16-bit
+   encoded samples, while the sampling rate does not need to be 16 kHz.
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  ./build/bin/sherpa-onnx-offline \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/tokens.txt \
+    ./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/test_wavs/test_ja_1.wav
+
+.. note::
+
+   Please use ``./build/bin/Release/sherpa-onnx-offline.exe`` for Windows.
+
+.. caution::
+
+   If you use Windows and get encoding issues, please run:
+
+      .. code-block:: bash
+
+          CHCP 65001
+
+   in your commandline.
+
+You should see the following output:
+
+.. literalinclude:: ./code-japanese/tdt-ctc-0.6b-int8.txt
+
+Speech recognition from a microphone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  ./build/bin/sherpa-onnx-microphone-offline \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/tokens.txt
+
+Speech recognition from a microphone with VAD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  cd /path/to/sherpa-onnx
+
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx
+
+  ./build/bin/sherpa-onnx-vad-microphone-offline-asr \
+    --silero-vad-model=./silero_vad.onnx \
+    --nemo-ctc-model=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/model.int8.onnx \
+    --tokens=./sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/tokens.txt


### PR DESCRIPTION
See also

| | English | Japanese|
|---|---|---|
|Original huggingface repo|[parakeet-tdt_ctc-110m](https://hf.co/nvidia/parakeet-tdt_ctc-110m)|[parakeet-tdt_ctc-0.6b-ja](https://hf.co/nvidia/parakeet-tdt_ctc-0.6b-ja)|
|Doc in sherpa-onnx|[sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/nemo/english.html#sherpa-onnx-nemo-parakeet-tdt-ctc-110m-en-36000-english)|[sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/nemo/japanese.html#sherpa-onnx-nemo-parakeet-tdt-ctc-0-6b-ja-35000-int8-japanese)|
|Real-time ASR Android APK|[Download](https://hf-mirror.com/csukuangfj/sherpa-onnx-apk/blob/main/vad-asr-simulated-streaming/1.12.4/sherpa-onnx-1.12.4-arm64-v8a-simulated_streaming_asr-en-parakeet_tdt_ctc_110m.apk)|[Download](https://hf-mirror.com/csukuangfj/sherpa-onnx-apk/blob/main/vad-asr-simulated-streaming/1.12.4/sherpa-onnx-1.12.4-arm64-v8a-simulated_streaming_asr-ja-parakeet-tdt_ctc_0.6b_ja.apk)|