### PR TITLE
Add doc for whisper distil-large-v3 and distil-large-v3.5

### DIFF
--- a/docs/source/onnx/pretrained_models/whisper/export-onnx.rst
+++ b/docs/source/onnx/pretrained_models/whisper/export-onnx.rst
@@ -63,6 +63,12 @@ from the following huggingface repositories:
  * - ``distil-large-v2``
    - `<https://huggingface.co/csukuangfj/sherpa-onnx-whisper-distil-large-v2>`_
    - `Here <https://hf-mirror.com/csukuangfj/sherpa-onnx-whisper-distil-large-v2>`_
+ * - ``distil-large-v3``
+   - `<https://huggingface.co/csukuangfj/sherpa-onnx-whisper-distil-large-v3>`_
+   - `Here <https://hf-mirror.com/csukuangfj/sherpa-onnx-whisper-distil-large-v3>`_
+ * - ``distil-large-v3.5``
+   - `<https://huggingface.co/csukuangfj/sherpa-onnx-whisper-distil-large-v3.5>`_
+   - `Here <https://hf-mirror.com/csukuangfj/sherpa-onnx-whisper-distil-large-v3.5>`_
  * - ``medium-aishell``
    - `<https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium-aishell>`_
    - `Here <https://hf-mirror.com/csukuangfj/sherpa-onnx-whisper-medium-aishell2>`_
@@ -104,11 +110,11 @@ It will print the following message:
 .. code-block:: bash
 
   usage: export-onnx.py [-h] --model
-                        {tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large,large-v1,large-v2,large-v3,distil-medium.en,distil-small.en,distil-large-v2,medium-aishell}
+                        {tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large,large-v1,large-v2,large-v3,distil-medium.en,distil-small.en,distil-large-v2,distil-large-v3,distil-large-v3.5,medium-aishell}
 
   optional arguments:
     -h, --help            show this help message and exit
-    --model {tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large,large-v1,large-v2,large-v3,distil-medium.en,distil-small.en,distil-large-v2,medium-aishell}
+    --model {tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large,large-v1,large-v2,large-v3,distil-medium.en,distil-small.en,distil-large-v2,distil-large-v3,distil-large-v3.5,medium-aishell}
 
 
 Example 1: Export tiny.en

--- a/docs/source/onnx/pretrained_models/whisper/large-v3.rst
+++ b/docs/source/onnx/pretrained_models/whisper/large-v3.rst
@@ -29,7 +29,7 @@ You can use the following commands to download the exported `onnx`_ models of ``
 .. hint::
 
    Please replace ``large-v3`` with
-   ``large``, ``large-v1``, ``large-v2``, and ``distil-large-v2``
+   ``large``, ``large-v1``, ``large-v2``, ``distil-large-v2``, ``distil-large-v3``, and ``distil-large-v3.5``
    if you want to try a different type of model.
 
 .. code-block:: bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added distil-large-v3 and distil-large-v3.5 to the available Whisper ONNX models list, with links.
  - Updated export usage text and command-line options to include the new models.
  - Extended download hints for pre-exported large-v3 variants to cover the new distil models.
  - No changes to behavior or APIs; documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->