### PR TITLE
Add doc for RKNN sense-voice models

### DIFF
--- a/docs/source/onnx/rknn/code-sense-voice-2024-04-17/cortex-a55.txt
+++ b/docs/source/onnx/rknn/code-sense-voice-2024-04-17/cortex-a55.txt
@@ -1,0 +1,14 @@
+/k2-fsa/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-offline --num-threads=1 --sense-voice-model=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx --tokens=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt", num_threads=1, debug=False, provider="cpu", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+Done!
+
+./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+{"lang": "<|zh|>", "emotion": "<|NEUTRAL|>", "event": "<|Speech|>", "text": "开饭时间早上九点至下午五点", "timestamps": [0.72, 0.96, 1.26, 1.44, 1.92, 2.10, 2.58, 2.82, 3.30, 3.90, 4.20, 4.56, 4.74], "durations": [], "tokens":["开", "饭", "时", "间", "早", "上", "九", "点", "至", "下", "午", "五", "点"], "words": []}
+----
+num threads: 1
+decoding method: greedy_search
+Elapsed seconds: 2.459 s
+Real time factor (RTF): 2.459 / 5.592 = 0.440

--- a/docs/source/onnx/rknn/code-sense-voice-2024-04-17/cortex-a76.txt
+++ b/docs/source/onnx/rknn/code-sense-voice-2024-04-17/cortex-a76.txt
@@ -1,0 +1,14 @@
+/k2-fsa/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-offline --num-threads=1 --sense-voice-model=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx --tokens=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt", num_threads=1, debug=False, provider="cpu", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+Done!
+
+./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+{"lang": "<|zh|>", "emotion": "<|NEUTRAL|>", "event": "<|Speech|>", "text": "开饭时间早上九点至下午五点", "timestamps": [0.72, 0.96, 1.26, 1.44, 1.92, 2.10, 2.58, 2.82, 3.30, 3.90, 4.20, 4.56, 4.74], "durations": [], "tokens":["开", "饭", "时", "间", "早", "上", "九", "点", "至", "下", "午", "五", "点"], "words": []}
+----
+num threads: 1
+decoding method: greedy_search
+Elapsed seconds: 0.561 s
+Real time factor (RTF): 0.561 / 5.592 = 0.100

--- a/docs/source/onnx/rknn/code-sense-voice-2024-04-17/lei-jun-test.txt
+++ b/docs/source/onnx/rknn/code-sense-voice-2024-04-17/lei-jun-test.txt
@@ -1,0 +1,56 @@
+/k2-fsa/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-vad-with-offline-asr sherpa-onnx-vad-with-offline-asr --num-threads=-1 --provider=rknn --silero-vad-model=./silero_vad.onnx --silero-vad-threshold=0.4 --sense-voice-model=./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn --tokens=./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt ./lei-jun-test.wav 
+
+VadModelConfig(silero_vad=SileroVadModelConfig(model="./silero_vad.onnx", threshold=0.4, min_silence_duration=0.5, min_speech_duration=0.25, max_speech_duration=20, window_size=512), ten_vad=TenVadModelConfig(model="", threshold=0.5, min_silence_duration=0.5, min_speech_duration=0.25, max_speech_duration=20, window_size=256), sample_rate=16000, num_threads=1, provider="cpu", debug=False)
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt", num_threads=-1, debug=False, provider="rknn", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Recognizer created!
+Started
+Reading: ./lei-jun-test.wav
+Started!
+28.934 -- 36.140: 朋友们晚上好欢迎大家来参加今天晚上的活动谢谢大家
+42.118 -- 57.676: 这是我第四次颁年度演讲前三次呢因为疫情的原因都在小米科技园内举办现场的人很少这是第四次
+58.182 -- 67.052: 我们仔细想了想我们还是想办一个比较大的聚会然后呢让我们的新朋友老朋友一起聚一聚
+67.718 -- 71.084: 今天的话呢我们就在北京的
+71.654 -- 91.580: 国家会议中心呢举办了这么一个活动现场呢来了很多人大概有三千五百人还有很多很多的朋友呢通过观看直播的方式来参与再一次呢对大家的参加表示感谢谢谢大家
+98.470 -- 104.748: 两个月前我参加了今年武汉大学的毕业典礼
+105.894 -- 110.828: 今年呢是武汉大学建校一百三十周年
+111.750 -- 117.388: 作为校友被母校邀请在毕业典礼上致辞
+118.022 -- 122.988: 这对我来说是至高无上的荣誉
+123.654 -- 128.716: 站在讲台的那一刻面对全校师生
+129.190 -- 134.348: 关于武大的所有的记忆一下子涌现在脑海里
+134.950 -- 139.660: 今天呢我就先和大家聊聊五大往事
+141.830 -- 144.012: 那还是三十六年前
+145.926 -- 147.756: 一九八七年
+148.678 -- 151.724: 我呢考上了武汉大学的计算机系
+152.646 -- 156.876: 在武汉大学的图书馆里看了一本书
+157.574 -- 158.796: 硅谷之火
+159.302 -- 161.708: 建立了我一生的梦想
+163.302 -- 164.524: 看完书以后
+165.286 -- 166.636: 热血沸腾
+167.590 -- 169.644: 激动的睡不着觉
+170.406 -- 171.308: 我还记得
+172.006 -- 174.764: 那天晚上星光很亮
+175.398 -- 177.836: 我就在武大的操场上
+178.342 -- 179.948: 就是屏幕上这个操场
+180.774 -- 185.420: 走了一圈又一圈走了整整一个晚上
+186.470 -- 187.852: 我心里有团火
+188.934 -- 191.884: 我也想办一个伟大的公司
+193.958 -- 194.988: 就是这样
+197.574 -- 202.540: 梦想之火在我心里彻底点燃了
+209.734 -- 212.748: 但是一个大一的新生
+220.230 -- 222.828: 但是一个大一的新生
+223.782 -- 227.276: 一个从县城里出来的年轻人
+228.134 -- 230.796: 什么也不会什么也没有
+231.526 -- 236.428: 就想创办一家伟大的公司这不就是天方夜谭吗
+237.574 -- 242.572: 这么离谱的一个梦想该如何实现呢
+243.846 -- 246.988: 那天晚上我想了一整晚上
+247.974 -- 249.068: 说实话
+250.342 -- 253.900: 越想越糊涂完全理不清头绪
+254.982 -- 261.516: 后来我在想哎干脆别想了把书练好是正事
+262.150 -- 265.868: 所以呢我就下定决心认认真真读书
+266.630 -- 267.308: 那么
+268.486 -- 271.692: 我怎么能够把书读的不同凡响呢
+num threads: -1
+decoding method: greedy_search
+Elapsed seconds: 47.488 s
+Real time factor (RTF): 47.488 / 272.398 = 0.174

--- a/docs/source/onnx/rknn/code-sense-voice-2024-04-17/npu.txt
+++ b/docs/source/onnx/rknn/code-sense-voice-2024-04-17/npu.txt
@@ -1,0 +1,14 @@
+/k2-fsa/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-offline --provider=rknn --num-threads=-1 --sense-voice-model=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn --tokens=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt", num_threads=-1, debug=False, provider="rknn", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+Done!
+
+./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+{"lang": "<|zh|>", "emotion": "<|NEUTRAL|>", "event": "<|Speech|>", "text": "开放时间早上九点至下午五点", "timestamps": [0.72, 0.96, 1.26, 1.44, 1.92, 2.10, 2.58, 2.82, 3.30, 3.90, 4.20, 4.56, 4.74], "durations": [], "tokens":["开", "放", "时", "间", "早", "上", "九", "点", "至", "下", "午", "五", "点"], "words": []}
+----
+num threads: -1
+decoding method: greedy_search
+Elapsed seconds: 0.721 s
+Real time factor (RTF): 0.721 / 5.592 = 0.129

--- a/docs/source/onnx/rknn/code-sense-voice-2024-04-17/short.txt
+++ b/docs/source/onnx/rknn/code-sense-voice-2024-04-17/short.txt
@@ -1,0 +1,14 @@
+/k2-fsa/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:372 sherpa-onnx-offline --num-threads=-2 --provider=rknn --sense-voice-model=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn --tokens=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt ./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/test_wavs/zh.wav 
+
+OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), telespeech_ctc="", tokens="./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt", num_threads=-2, debug=False, provider="rknn", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(dict_dir="", lexicon="", rule_fsts=""))
+Creating recognizer ...
+Started
+Done!
+
+./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/test_wavs/zh.wav
+{"lang": "<|zh|>", "emotion": "<|NEUTRAL|>", "event": "<|Speech|>", "text": "开放时间早上九点至下午五点", "timestamps": [0.72, 0.96, 1.26, 1.44, 1.92, 2.10, 2.58, 2.82, 3.30, 3.90, 4.20, 4.56, 4.74], "durations": [], "tokens":["开", "放", "时", "间", "早", "上", "九", "点", "至", "下", "午", "五", "点"], "words": []}
+----
+num threads: -2
+decoding method: greedy_search
+Elapsed seconds: 0.521 s
+Real time factor (RTF): 0.521 / 5.592 = 0.093

--- a/docs/source/onnx/rknn/index.rst
+++ b/docs/source/onnx/rknn/index.rst
@@ -12,7 +12,7 @@ The following boards are known to work:
   - RK3562
 
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 8
 
    ./tutorials.rst
    ./install.rst

--- a/docs/source/onnx/rknn/install.rst
+++ b/docs/source/onnx/rknn/install.rst
@@ -63,6 +63,124 @@ You can download ``librknnrt.so`` ``2.2.0`` from:
 
   `<https://github.com/airockchip/rknn-toolkit2/blob/v2.2.0/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so>`_
 
+.. caution::
+
+   ``/lib/librknnrt.so`` is used in the above since it is in the output of ``ldd $(which sherpa-onnx)``.
+
+   You need to change it to match your case. For instance, if it is ``/usr/lib/librknnrt.so``
+   in your output, then you should use::
+
+      strings /usr/lib/librknnrt.so | grep "librknnrt version"
+
+Download pre-compiled binaries
+----------------------------------------
+
+You can download pre-compiled binaries from
+
+  `<https://github.com/k2-fsa/sherpa-onnx/releases>`_
+
+Please always use the ``latest version``. For the version ``v1.12.13``, you can visit
+
+  `<https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.12.13>`_
+
+and select
+
+  - Static link: `sherpa-onnx-v1.12.13-rknn-linux-aarch64-static.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.13/sherpa-onnx-v1.12.13-rknn-linux-aarch64-static.tar.bz2>`_
+  - Dynamic link: `sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.13/sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared.tar.bz2>`_
+
+We use the dynamically linked binaries as an example below.
+
+.. code-block:: bash
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.13/sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared.tar.bz2
+   tar xvf sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared.tar.bz2
+
+.. code-block:: bash
+
+  orangepi@orangepi5max:~$ ls -lh sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared
+  total 8.0K
+  drwxr-xr-x 2 orangepi orangepi 4.0K Sep 12  2025 bin
+  drwxr-xr-x 2 orangepi orangepi 4.0K Sep 12  2025 lib
+  orangepi@orangepi5max:~$ ls -lh sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared/lib/
+  total 18M
+  -rw-r--r-- 1 orangepi orangepi  13M Sep 12  2025 libonnxruntime.so
+  -rwxr-xr-x 1 orangepi orangepi 4.7M Sep 12  2025 libsherpa-onnx-c-api.so
+  -rwxr-xr-x 1 orangepi orangepi 217K Sep 12  2025 libsherpa-onnx-cxx-api.so
+  orangepi@orangepi5max:~$ ls  sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared/bin/
+  sherpa-onnx                                            sherpa-onnx-offline                          sherpa-onnx-offline-zeroshot-tts
+  sherpa-onnx-alsa                                       sherpa-onnx-offline-audio-tagging            sherpa-onnx-online-punctuation
+  sherpa-onnx-alsa-offline                               sherpa-onnx-offline-denoiser                 sherpa-onnx-online-websocket-client
+  sherpa-onnx-alsa-offline-audio-tagging                 sherpa-onnx-offline-language-identification  sherpa-onnx-online-websocket-server
+  sherpa-onnx-alsa-offline-speaker-identification        sherpa-onnx-offline-parallel                 sherpa-onnx-vad
+  sherpa-onnx-keyword-spotter                            sherpa-onnx-offline-punctuation              sherpa-onnx-vad-alsa
+  sherpa-onnx-keyword-spotter-alsa                       sherpa-onnx-offline-source-separation        sherpa-onnx-vad-alsa-offline-asr
+  sherpa-onnx-keyword-spotter-microphone                 sherpa-onnx-offline-speaker-diarization      sherpa-onnx-vad-microphone
+  sherpa-onnx-microphone                                 sherpa-onnx-offline-tts                      sherpa-onnx-vad-microphone-offline-asr
+  sherpa-onnx-microphone-offline                         sherpa-onnx-offline-tts-play                 sherpa-onnx-vad-with-offline-asr
+  sherpa-onnx-microphone-offline-audio-tagging           sherpa-onnx-offline-tts-play-alsa            sherpa-onnx-vad-with-online-asr
+  sherpa-onnx-microphone-offline-speaker-identification  sherpa-onnx-offline-websocket-server         sherpa-onnx-version
+
+.. code-block:: bash
+
+  orangepi@orangepi5max:~$ ldd sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared/bin/sherpa-onnx
+
+          linux-vdso.so.1 (0x0000007fae61e000)
+          librknnrt.so (0x0000007fadee0000)
+          libonnxruntime.so (0x0000007fad250000)
+          libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000007fad230000)
+          libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000007fad190000)
+          libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000007facf60000)
+          libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000007facf30000)
+          libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007facd80000)
+          libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000007facd60000)
+          librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000007facd40000)
+          /lib/ld-linux-aarch64.so.1 (0x0000007fae5e5000)
+
+
+.. code-block:: bash
+
+  orangepi@orangepi5max:~$ readelf -d sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared/bin/sherpa-onnx
+
+  Dynamic section at offset 0x1dfc20 contains 31 entries:
+    Tag        Type                         Name/Value
+   0x0000000000000001 (NEEDED)             Shared library: [librknnrt.so]
+   0x0000000000000001 (NEEDED)             Shared library: [libonnxruntime.so]
+   0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
+   0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+   0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
+   0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
+   0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+   0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib:$ORIGIN/../../../sherpa_onnx/lib]
+   0x000000000000000c (INIT)               0x410000
+   0x000000000000000d (FINI)               0x5671b4
+   0x0000000000000019 (INIT_ARRAY)         0x5d4c58
+   0x000000000000001b (INIT_ARRAYSZ)       32 (bytes)
+   0x000000000000001a (FINI_ARRAY)         0x5d4c78
+   0x000000000000001c (FINI_ARRAYSZ)       8 (bytes)
+   0x000000006ffffef5 (GNU_HASH)           0x400308
+   0x0000000000000005 (STRTAB)             0x4024e0
+   0x0000000000000006 (SYMTAB)             0x400590
+   0x000000000000000a (STRSZ)              13777 (bytes)
+   0x000000000000000b (SYMENT)             24 (bytes)
+   0x0000000000000015 (DEBUG)              0x0
+   0x0000000000000003 (PLTGOT)             0x5dffe8
+   0x0000000000000002 (PLTRELSZ)           5328 (bytes)
+   0x0000000000000014 (PLTREL)             RELA
+   0x0000000000000017 (JMPREL)             0x408da8
+   0x0000000000000007 (RELA)               0x405f10
+   0x0000000000000008 (RELASZ)             11928 (bytes)
+   0x0000000000000009 (RELAENT)            24 (bytes)
+   0x000000006ffffffe (VERNEED)            0x405d50
+   0x000000006fffffff (VERNEEDNUM)         6
+   0x000000006ffffff0 (VERSYM)             0x405ab2
+   0x0000000000000000 (NULL)               0x0
+
+To check that you have configured it correctly, run::
+
+  orangepi@orangepi5max:~$ ./sherpa-onnx-v1.12.13-rknn-linux-aarch64-shared/bin/sherpa-onnx --help
+
+It should print help information for the binary ``sherpa-onnx``.
+
 Build sherpa-onnx directly on your board
 ----------------------------------------
 

--- a/docs/source/onnx/rknn/models.rst
+++ b/docs/source/onnx/rknn/models.rst
@@ -1,7 +1,6 @@
 Pre-trained models
 ==================
 
-
 You can download pre-trained models for RKNPU from `<https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models>`_.
 
 In the following, we use models for ``rk3588`` as an example. You can replace
@@ -16,12 +15,14 @@ to install `sherpa-onnx`_. The following is an example of installing
 
   (py310) orangepi@orangepi5max:~/t$ uname -a
   Linux orangepi5max 6.1.43-rockchip-rk3588 #1.0.0 SMP Mon Jul  8 11:54:40 CST 2024 aarch64 aarch64 aarch64 GNU/Linux
-  (py310) orangepi@orangepi5max:~/t$ ls -lh sherpa_onnx-1.11.2-cp310-cp310-linux_aarch64.whl
-  -rw-r--r-- 1 orangepi orangepi 17M Mar  8 00:20 sherpa_onnx-1.11.2-cp310-cp310-linux_aarch64.whl
-  (py310) orangepi@orangepi5max:~/t$ pip install ./sherpa_onnx-1.11.2-cp310-cp310-linux_aarch64.whl
-  Processing ./sherpa_onnx-1.11.2-cp310-cp310-linux_aarch64.whl
+
+  (py310) orangepi@orangepi5max:~/t$ ls -lh sherpa_onnx-1.12.13-cp310-cp310-manylinux_2_27_aarch64.whl
+  -rw-r--r-- 1 orangepi orangepi 22M Mar 11 14:58 sherpa_onnx-1.12.13-cp310-cp310-manylinux_2_27_aarch64.whl
+
+  (py310) orangepi@orangepi5max:~/t$ pip install ./sherpa_onnx-1.12.13-cp310-cp310-manylinux_2_27_aarch64.whl
+  Processing ./sherpa_onnx-1.12.13-cp310-cp310-manylinux_2_27_aarch64.whl
   Installing collected packages: sherpa-onnx
-  Successfully installed sherpa-onnx-1.11.2
+  Successfully installed sherpa-onnx-1.12.13
 
   (py310) orangepi@orangepi5max:~/t$ which sherpa-onnx
   /home/orangepi/py310/bin/sherpa-onnx
@@ -274,3 +275,255 @@ You should see the following output::
   1:现在是星期六
   2:二零二五年三月二十二号
   3:下午六点四十四分
+
+.. _sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17:
+
+sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17 (Chinese, English, Japanese, Korean, Cantonese, 中英日韩粤语)
+--------------------------------------------------------------------------------------------------------------------------------------------
+
+This model is converted from :ref:`sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17` using code from the following URL:
+
+  `<https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/sense-voice/rknn>`_
+
+.. hint::
+
+   You can find how to run the export code at
+
+      `<https://github.com/k2-fsa/sherpa-onnx/blob/master/.github/workflows/export-sense-voice-to-rknn.yaml>`_
+
+The original PyTorch checkpoint is available at
+
+  `<https://huggingface.co/FunAudioLLM/SenseVoiceSmall>`_
+
+Since the original `SenseVoice`_ model is a non-streaming model and RKNN does not support dynamic input shapes, we
+have to fix how long the model can process when exporting to RKNN.
+
+The ``20-seconds`` in the model name means the model can only handle audio of duration 20 seconds.
+
+  - If the input audio is less than 20 seconds, it is padded to 20 seconds in the code automatically.
+  - If the input audio is larger than 20 seconds, it is truncated to 20 seconds in the code automatically.
+
+We provide exported models of different input lengths. See the table below.
+
+.. list-table::
+
+ * - Max input lengths
+   - URL
+ * - 10 seconds
+   - `sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2>`_
+ * - 15 seconds
+   - `sherpa-onnx-rk3588-15-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-15-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2>`_
+ * - 20 seconds
+   - `sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2>`_
+ * - 25 seconds
+   - `sherpa-onnx-rk3588-25-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-25-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2>`_
+ * - 30 seconds
+   - `sherpa-onnx-rk3588-30-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2 <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-30-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2>`_
+
+.. hint::
+
+    The above table lists models foro ``rk3588``. You can replace
+    ``rk3588`` with ``rk3576``, ``rk3568``, ``rk3566`` or ``rk3562``.
+
+We suggest that you use a :ref:`sherpa_onnx_vad` to segment your input audio into short segments.
+
+.. note::
+
+   You can use::
+
+    watch -n 0.5 cat /sys/kernel/debug/rknpu/load
+
+   to watch the usage of NPU.
+
+   For the RK3588 board, you can use:
+
+    - ``--num-threads=1`` to select ``RKNN_NPU_CORE_AUTO``
+    - ``--num-threads=0`` to select ``RKNN_NPU_CORE_0``
+    - ``--num-threads=-1`` to select ``RKNN_NPU_CORE_1``
+    - ``--num-threads=-2`` to select ``RKNN_NPU_CORE_2``
+    - ``--num-threads=-3`` to select ``RKNN_NPU_CORE_0_1``
+    - ``--num-threads=-4`` to select ``RKNN_NPU_CORE_0_1_2``
+
+Decode long files with a VAD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example demonstrates how to use a ``20-second`` model to decode a long wave file.
+
+.. code-block::
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/lei-jun-test.wav
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+   tar xvf sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+
+Then run:
+
+.. code-block:: bash
+
+  sherpa-onnx-vad-with-offline-asr \
+    --num-threads=-1 \
+    --provider=rknn \
+    --silero-vad-model=./silero_vad.onnx \
+    --silero-vad-threshold=0.4 \
+    --sense-voice-model=./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn \
+    --tokens=./sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt \
+    ./lei-jun-test.wav
+
+.. raw:: html
+
+  <table>
+    <tr>
+      <th>Wave filename</th>
+      <th>Content</th>
+    </tr>
+    <tr>
+      <td>lei-jun-test.wav</td>
+      <td>
+       <audio title="lei-jun-test.wav" controls="controls">
+             <source src="/sherpa/_static/sense-voice/lei-jun-test.wav" type="audio/wav">
+             Your browser does not support the <code>audio</code> element.
+       </audio>
+      </td>
+    </tr>
+  </table>
+
+The output is given below:
+
+
+.. container:: toggle
+
+    .. container:: header
+
+      Click ▶ to see the output
+
+    .. literalinclude:: ./code-sense-voice-2024-04-17/lei-jun-test.txt
+
+Decode a short file
+~~~~~~~~~~~~~~~~~~~
+
+The following example demonstrates how to use a ``10-second`` model to decode a short wave file.
+
+.. code-block::
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+   tar xvf sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+
+.. code-block:: bash
+
+  sherpa-onnx-offline \
+    --num-threads=-2 \
+    --provider=rknn \
+    --sense-voice-model=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn \
+    --tokens=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt \
+    ./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/test_wavs/zh.wav
+
+The output is given below:
+
+.. literalinclude:: ./code-sense-voice-2024-04-17/short.txt
+
+Speed test
+~~~~~~~~~~
+
+We compare the speed between the ``int8.onnx`` model and the ``10-second`` rknn model for
+
+  - 1 Cortex A55 CPU with ``int8.onnx``
+  - 1 Cortex A76 CPU with ``int8.onnx``
+  - 1 RK NPU on RK3588
+
+Please first use the following command to download the test model files:
+
+.. code-block:: bash
+
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2
+  tar xvf sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17.tar.bz2
+
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+  tar xvf sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2
+
+The results are summarized in the following table. 
+
+
+.. list-table::
+
+ * -
+   - | 1 Cortex A55 CPU
+     | with ``int8 ONNX`` model
+   - | 1 Cortex A76 CPU
+     | with ``int8 ONNX`` model
+   - 1 RK3588 NPU
+ * - RTF
+   - 0.440
+   - 0.100
+   - 0.129
+
+You can find detailed test commands below.
+
+Sense-voice ``int8`` ONNX model on 1 Cortex A55 CPU
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+.. code-block:: bash
+
+  taskset 0x01 sherpa-onnx-offline \
+    --num-threads=1 \
+    --sense-voice-model=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx \
+    --tokens=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt \
+    ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+
+The output is given below:
+
+.. literalinclude:: ./code-sense-voice-2024-04-17/cortex-a55.txt
+
+Sense-voice ``int8`` ONNX model on 1 Cortex A76 CPU
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+.. code-block:: bash
+
+  taskset 0x10 sherpa-onnx-offline \
+    --num-threads=1 \
+    --sense-voice-model=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/model.int8.onnx \
+    --tokens=./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/tokens.txt \
+    ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+
+The output is given below:
+
+.. literalinclude:: ./code-sense-voice-2024-04-17/cortex-a76.txt
+
+Sense-voice RKNN model on 1 RK3588 NPU
+::::::::::::::::::::::::::::::::::::::
+
+.. code-block:: bash
+
+  taskset 0x01 sherpa-onnx-offline \
+    --provider=rknn \
+    --num-threads=-1 \
+    --sense-voice-model=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/model.rknn \
+    --tokens=./sherpa-onnx-rk3588-10-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17/tokens.txt \
+    ./sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17/test_wavs/zh.wav
+
+The output is given below:
+
+.. literalinclude:: ./code-sense-voice-2024-04-17/npu.txt
+
+
+.. _sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2025-09-09:
+
+sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2025-09-09 (Chinese, English, Japanese, Korean, Cantonese, 中英日韩粤语)
+--------------------------------------------------------------------------------------------------------------------------------------------
+
+This model is converted from :ref:`sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09` using code from the following URL:
+
+  `<https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/sense-voice/rknn>`_
+
+.. hint::
+
+   You can find how to run the export code at
+
+      `<https://github.com/k2-fsa/sherpa-onnx/blob/master/.github/workflows/export-sense-voice-to-rknn.yaml>`_
+
+The original PyTorch checkpoint is available at
+
+  `<https://huggingface.co/ASLP-lab/WSYue-ASR/tree/main/sensevoice_small_yue>`_
+
+Please refer to :ref:`sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17` for how to use this model.

--- a/docs/source/onnx/sense-voice/pretrained.rst
+++ b/docs/source/onnx/sense-voice/pretrained.rst
@@ -23,6 +23,10 @@ It supports the following 5 languages:
 In the following, we describe how to use it.
 
 
+.. hint::
+
+   For RKNN users, please refer to :ref:`sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2024-07-17`.
+
 Huggingface space
 ^^^^^^^^^^^^^^^^^
 
@@ -231,6 +235,10 @@ It supports the following 5 languages:
 
    If you want a ``Cantonese`` ASR model, please choose this model or
    :ref:`sherpa-onnx-wenetspeech-yue-u2pp-conformer-ctc-zh-en-cantonese-int8-2025-09-10`
+
+.. hint::
+
+   For RKNN users, please refer to :ref:`sherpa-onnx-rk3588-20-seconds-sense-voice-zh-en-ja-ko-yue-2025-09-09`.
 
 In the following, we describe how to use it.
 

--- a/docs/source/onnx/vad/index.rst
+++ b/docs/source/onnx/vad/index.rst
@@ -1,3 +1,5 @@
+.. _sherpa_onnx_vad:
+
 VAD
 ===
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added RKNN SenseVoice offline recognition examples (including VAD + offline ASR) with sample outputs and performance metrics for multiple devices.
  * Expanded install guide with cautions for runtime library, precompiled binary downloads, verification steps, and usage tips.
  * Updated models page with RK3588 20‑second SenseVoice variants and version updates, plus usage guidance for different input lengths.
  * Added cross-links guiding RKNN users from SenseVoice pretrained docs to RK3588 guides.
  * Increased RKNN docs navigation depth for easier browsing.
  * Introduced an anchor for the VAD section to enable direct linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->