### PR TITLE
fix: update config file format to use key=value syntax

### DIFF
--- a/docs/source/onnx/spacemit/provider-config.rst
+++ b/docs/source/onnx/spacemit/provider-config.rst
@@ -38,14 +38,14 @@ The config file is a plain text file.
 
 - Empty lines are ignored
 - Lines starting with ``#`` are ignored
-- Each entry uses ``key: value`` format
+- Each entry uses ``key=value`` format or ``key = value``
 
 For example:
 
 .. code-block:: text
 
    # Example SpacemiT provider config
-   SPACEMIT_EP_INTRA_THREAD_NUM: 4
+   SPACEMIT_EP_INTRA_THREAD_NUM=4
 
 Common options
 --------------
@@ -106,5 +106,5 @@ You can create a minimal provider config file like this:
 
 .. code-block:: text
 
-   SPACEMIT_EP_INTRA_THREAD_NUM:4
-   SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD:1
+   SPACEMIT_EP_INTRA_THREAD_NUM=4
+   SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD=1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider configuration syntax documentation to reflect new format, changing configuration entries from colon-delimited (`key: value`) to equals-delimited (`key=value`) format with corresponding example updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->