### PR TITLE
Update doc for KittenTTS

### DIFF
--- a/docs/source/onnx/tts/kitten.rst
+++ b/docs/source/onnx/tts/kitten.rst
@@ -6,6 +6,30 @@ KittenTTS
 This page explains how to use `sherpa-onnx`_ with
 `KittenTTS <https://github.com/KittenML/KittenTTS>`_.
 
+The following KittenTTS models are available. Visit the links below for
+detailed documentation, download instructions, and code examples for each model.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Model
+     - Documentation
+   * - kitten-nano-en-v0_1-fp16
+     - `kitten-nano-en-v0_1 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-nano-en-v0_1.html>`_
+   * - kitten-nano-en-v0_2-fp16
+     - `kitten-nano-en-v0_2 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-nano-en-v0_2.html>`_
+   * - kitten-mini-en-v0_1-fp16
+     - `kitten-mini-en-v0_1 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-mini-en-v0_1.html>`_
+   * - kitten-nano-en-v0_8-fp32
+     - `kitten-nano-en-v0_8-fp32 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-nano-en-v0_8-fp32.html>`_
+   * - kitten-nano-en-v0_8-int8
+     - `kitten-nano-en-v0_8-int8 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-nano-en-v0_8-int8.html>`_
+   * - kitten-micro-en-v0_8
+     - `kitten-micro-en-v0_8 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-micro-en-v0_8.html>`_
+   * - kitten-mini-en-v0_8
+     - `kitten-mini-en-v0_8 <https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-mini-en-v0_8.html>`_
+
 KittenTTS is a compact English text-to-speech model. It does not require a
 reference audio prompt. You select a speaker with ``--sid`` and synthesize
 audio directly.

--- a/docs/source/onnx/tts/pretrained_models/kitten.rst
+++ b/docs/source/onnx/tts/pretrained_models/kitten.rst
@@ -1,6 +1,8 @@
 KittenTTS
 =========
 
+Please see also `<https://k2-fsa.github.io/sherpa/onnx/tts/kitten>`_.
+
 This page lists pre-trained models from `<https://github.com/KittenML/KittenTTS>`_.
 
 .. _kitten-nano-v01:


### PR DESCRIPTION
Please see doc at https://k2-fsa.github.io/sherpa/onnx/tts/kitten.html

<img width="2346" height="1284" alt="Screenshot 2026-05-12 at 17 39 40" src="https://github.com/user-attachments/assets/87ac2e62-2421-436e-ae5a-94a8e5871db9" />


https://k2-fsa.github.io/sherpa/onnx/tts/all/English/kitten-nano-en-v0_8-fp32.html

<img width="2716" height="1814" alt="Screenshot 2026-05-12 at 17 39 59" src="https://github.com/user-attachments/assets/cbd153e0-b598-46ce-92ab-26f505166d38" />

See also https://github.com/k2-fsa/sherpa-onnx/pull/3591

cc @dewana-sl


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive list of available KittenTTS pre-trained model variants with direct links to their documentation and download pages.
  * Added a reference link to the Sherpa ONNX TTS KittenTTS documentation for easier navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa/pull/832)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->