### PR TITLE
docs: add nemotron-3.5-asr-streaming-0.6b multilingual section

### DIFF
--- a/docs/source/onnx/nemo/nemotron-streaming.rst
+++ b/docs/source/onnx/nemo/nemotron-streaming.rst
@@ -121,3 +121,159 @@ Please use the following command for real-time speech recognition with a microph
      --decoder=./sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25/decoder.int8.onnx \
      --joiner=./sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25/joiner.int8.onnx \
      --tokens=./sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25/tokens.txt
+
+sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11 (Multilingual)
+--------------------------------------------------------------------------------
+
+This section describes how to use the multilingual model
+`nemotron-3.5-asr-streaming-0.6b <https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b>`_
+in `sherpa-onnx`_.
+
+Unlike the English-only model above, a single model supports 40 language-locales
+from one checkpoint. The language is selected per-stream as a string
+(e.g. ``en``, ``ja``, ``hi``); an empty string or ``auto`` lets the model
+detect the language automatically.
+
+The 19 transcription-ready locales work out of the box:
+
+  English (en-US, en-GB), Spanish (es-US, es-ES), French (fr-FR, fr-CA)
+
+  Italian (it-IT), Portuguese (pt-BR, pt-PT), Dutch (nl-NL), German (de-DE)
+
+  Turkish (tr-TR), Russian (ru-RU), Arabic (ar-AR), Hindi (hi-IN)
+
+  Japanese (ja-JP), Korean (ko-KR), Vietnamese (vi-VN), Ukrainian (uk-UA)
+
+It also covers 13 broad-coverage locales (usable, but with higher error rates):
+
+  Polish (pl-PL), Swedish (sv-SE), Czech (cs-CZ), Norwegian Bokmål (nb-NO)
+
+  Danish (da-DK), Bulgarian (bg-BG), Finnish (fi-FI), Croatian (hr-HR)
+
+  Slovak (sk-SK), Mandarin (zh-CN), Hungarian (hu-HU), Romanian (ro-RO)
+
+  Estonian (et-EE)
+
+A further 8 adaptation-ready locales require fine-tuning before they can transcribe:
+
+  Greek (el-GR), Lithuanian (lt-LT), Latvian (lv-LV), Maltese (mt-MT)
+
+  Slovenian (sl-SI), Hebrew (he-IL), Thai (th-TH), Norwegian Nynorsk (nn-NO)
+
+.. hint::
+
+   In ``auto`` mode the model detects the language and emits a tag such as
+   ``<en-US>`` in the output. `sherpa-onnx`_ strips these language tags so the
+   returned transcript stays clean.
+
+It also supports the same 4 chunk sizes: 80ms, 160ms, 560ms, and 1120ms.
+The following table lists the model for each chunk size:
+
+.. list-table::
+
+ * - Model
+   - Chunk size
+   - URL
+ * - ``sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11.tar.bz2``
+   - 80 ms
+   - `Download address <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11.tar.bz2>`_
+ * - ``sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11.tar.bz2``
+   - 160 ms
+   - `Download address <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11.tar.bz2>`_
+ * - ``sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11.tar.bz2``
+   - 560 ms
+   - `Download address <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11.tar.bz2>`_
+ * - ``sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2``
+   - 1120 ms
+   - `Download address <https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2>`_
+
+.. hint::
+
+   The larger the chunk size, the higher the accuracy.
+
+The following shows how to use the model with chunk size ``560ms``.
+
+Export to ONNX
+^^^^^^^^^^^^^^
+
+In case you want to export the model by yourself, please see the export script at
+
+  `<https://github.com/k2-fsa/sherpa-onnx/blob/master/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py>`_
+
+For normal users, you don't need to care about the export step. Just use the pre-exported model from us.
+
+Download the model
+^^^^^^^^^^^^^^^^^^
+
+Please use the following command to download the model:
+
+.. code-block::
+
+   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11.tar.bz2
+   tar xvf sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11.tar.bz2
+   rm sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11.tar.bz2
+
+   ls -lh sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
+
+You should see the following output:
+
+.. code-block::
+
+  ls -lh sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
+
+  total 1359632
+  -rw-r--r--@ 1 rpwr021  wheel    14M Jun 11 19:41 decoder.int8.onnx
+  -rw-r--r--@ 1 rpwr021  wheel   627M Jun 11 19:41 encoder.int8.onnx
+  -rw-r--r--@ 1 rpwr021  wheel   9.1M Jun 11 19:41 joiner.int8.onnx
+  -rw-r--r--@ 1 rpwr021  wheel   222B Jun 11 19:43 README.md
+  drwxr-xr-x@ 4 rpwr021  wheel   128B Jun 11 19:44 test_wavs
+  -rw-r--r--@ 1 rpwr021  wheel   128K Jun 11 19:33 tokens.txt
+
+Decode a wave file
+^^^^^^^^^^^^^^^^^^
+
+To force a specific language, pass ``--language`` with a language string,
+for example ``--language=ja`` for Japanese:
+
+.. code-block::
+
+   build/bin/sherpa-onnx \
+     --encoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/encoder.int8.onnx \
+     --decoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/decoder.int8.onnx \
+     --joiner=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/joiner.int8.onnx \
+     --tokens=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/tokens.txt \
+     --language=ja \
+     ./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/test_wavs/ja.wav
+
+To let the model detect the language automatically, use ``--language=auto``
+(this is also the behavior when ``--language`` is omitted):
+
+.. code-block::
+
+   build/bin/sherpa-onnx \
+     --encoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/encoder.int8.onnx \
+     --decoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/decoder.int8.onnx \
+     --joiner=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/joiner.int8.onnx \
+     --tokens=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/tokens.txt \
+     --language=auto \
+     ./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/test_wavs/en.wav
+
+.. hint::
+
+   The ``--language`` value is set per-stream. When using the C/C++/Python/Swift
+   APIs, set it on the stream with ``SetOption("language", "<lang>")`` before
+   feeding waveform samples.
+
+Real-time speech recognition from a microphone
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Please use the following command for real-time speech recognition with a microphone:
+
+.. code-block::
+
+   build/bin/sherpa-onnx-microphone \
+     --encoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/encoder.int8.onnx \
+     --decoder=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/decoder.int8.onnx \
+     --joiner=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/joiner.int8.onnx \
+     --tokens=./sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11/tokens.txt \
+     --language=auto


### PR DESCRIPTION
Adds a documentation section for the multilingual `nemotron-3.5-asr-streaming-0.6b` model on the existing Nemotron streaming page (`docs/source/onnx/nemo/nemotron-streaming.rst`).

Covers:
- per-stream `--language` selection and `auto` detection
- the three language-locale tiers (19 transcription-ready incl. Hindi, 13 broad-coverage, 8 adaptation-ready that need fine-tuning)
- download links for all four chunk sizes (80/160/560/1120 ms)
- decode (forced + auto) and microphone usage

Addresses the help-wanted request in k2-fsa/sherpa-onnx#3673. Note that issue is filed on the `sherpa-onnx` repo, but the rendered docs live here in `sherpa`.

The download `ls -lh` output is from a real extract of the published 560ms int8 archive. A decode-output `literalinclude` (like the English section has) is intentionally omitted; it can be added from a real run when convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added multilingual usage documentation for Nemotron Streaming
  * Introduced the `nemotron-3.5-asr-streaming-0.6b` model variant with per-stream language selection
  * Documented supported locales and language auto-detection capability
  * Included chunk-size-specific model downloads and updated example commands for file decoding and real-time microphone transcription

<!-- end of auto-generated comment: release notes by coderabbit.ai -->